### PR TITLE
expose --pieBranch param

### DIFF
--- a/docs/pack-question.md
+++ b/docs/pack-question.md
@@ -9,6 +9,7 @@ It generates 2 javascript files:
 > Note: This doesn't generate the final question for you. To do that you'll need to create the final html page, include the 2 js files above, and use a controller that can interact with the controller-map.js file. See [pie-docs](http://pielabs.github.io/pie-docs) for more infomation.
 
 ### Options
+  `--pieBranch` - what branch of the pie dependencies (pie-player, pie-control-panel, etc) to use: default: `develop`.
   `--clean` - clean build assets before packing. default: `false`
   `--support` - a js file to load to add support for a build type. See below.
   `--dir` - the relative path to a directory to use as the root. This should contain `config.json` and `index.html` (default: the current working directory)

--- a/src/question/packer.js
+++ b/src/question/packer.js
@@ -39,7 +39,7 @@ export default class Packer {
 
     logger.silly('[pack] opts: ', opts);
 
-    let npmDependencies = _.extend({}, DEFAULT_DEPENDENCIES, this._question.npmDependencies);
+    let npmDependencies = _.extend({}, DEFAULT_DEPENDENCIES(opts.pieBranch), this._question.npmDependencies);
 
     logger.debug('npm dependencies: ', JSON.stringify(npmDependencies));
 
@@ -93,18 +93,27 @@ export default class Packer {
   }
 }
 
-export const DEFAULT_DEPENDENCIES = {
-  'babel-core': '^6.17.0',
-  'babel-loader': '^6.2.5',
-  'style-loader': '^0.13.1',
-  'css-loader': '^0.25.0',
-  'babel-preset-es2015': '^6.16.0',
-  'css-loader': '^0.25.0',
-  'pie-player': 'PieLabs/pie-player',
-  'pie-controller': 'PieLabs/pie-controller',
-  'pie-control-panel': 'PieLabs/pie-control-panel',
-  'style-loader': '^0.13.1',
-  'webpack': '2.1.0-beta.21'
+export let DEFAULT_DEPENDENCIES = (branch) => {
+
+  branch = branch || 'master';
+
+  let branchSpecific = {
+    'pie-player': `PieLabs/pie-player#${branch}`,
+    'pie-controller': `PieLabs/pie-controller#${branch}`,
+    'pie-control-panel': `PieLabs/pie-control-panel#${branch}`
+  }
+
+  return _.extend({
+    'babel-core': '^6.17.0',
+    'babel-loader': '^6.2.5',
+    'style-loader': '^0.13.1',
+    'css-loader': '^0.25.0',
+    'babel-preset-es2015': '^6.16.0',
+    'css-loader': '^0.25.0',
+    'style-loader': '^0.13.1',
+    'webpack': '2.1.0-beta.21'
+
+  }, branchSpecific);
 };
 
 export const DEFAULTS = {
@@ -117,5 +126,6 @@ export const DEFAULTS = {
   keepBuildAssets: true,
   pieJs: 'pie.js',
   controllersJs: 'controllers.js',
-  fullInstall: false
+  fullInstall: false,
+  pieBranch: 'develop'
 }


### PR DESCRIPTION
Add a cli param `--pieBranch` that allows you to specify which branch of the pie dependencies to use. This is useful when we want to bundle say the `master` branch vs the `develop` branch. Once we start publishing this stuff to npm we can look at deprecating this option.