### PR TITLE
Add code to make adding excludes to a loader configurable

### DIFF
--- a/src/code-gen/element-bundle.js
+++ b/src/code-gen/element-bundle.js
@@ -88,7 +88,9 @@ function webpackBundle(root, entryJs, libraries, bundleName, getLoaders) {
     let orNames = libraries.join('|');
     let str = `node_modules/(?!(${orNames})/).*`;
     logger.debug('regex string: ', str);
-    l.exclude = new RegExp(str);
+    if(l.addExclude) {
+      l.exclude = new RegExp(str);
+    }
     return l;
   });
 

--- a/src/framework-support/frameworks/react.js
+++ b/src/framework-support/frameworks/react.js
@@ -1,12 +1,5 @@
 export let frameworkName = 'react';
 
-/** 
- * @param name 
- * @param resolve - a function to resolve the module by the given name.
- * using resolved modules due to issues w/ symlinking and webpack/babel-loader
- * @see: https://github.com/webpack/webpack/issues/1866
- * @see: https://github.com/babel/babel-loader/issues/149
- */
 export function support(dependencies) {
 
   if (!dependencies.react) {
@@ -28,7 +21,8 @@ export function support(dependencies) {
             presets: [
               'babel-preset-react'
             ]
-          }
+          },
+          addExclude: true
         }
       ]
     }

--- a/src/question/packer.js
+++ b/src/question/packer.js
@@ -108,7 +108,6 @@ export let DEFAULT_DEPENDENCIES = (branch) => {
     'babel-loader': '^6.2.5',
     'style-loader': '^0.13.1',
     'css-loader': '^0.25.0',
-    'css-loader': '^0.25.0',
     'style-loader': '^0.13.1',
     'webpack': '2.1.0-beta.21'
 


### PR DESCRIPTION
For styles i need to recurse into the npm packages. Currently all loaders are setup with an exclude property for npm_modules.
To make this configurable on a per loader bases, i've added a property "addExclude" to the framework  loader config. 
When the webpack config is generated, the excludes are added only when addExclude is true

