### PR TITLE
Duplicate loaders should be reduced to 1 loader if the version range of each is compatible

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,6 +13,7 @@ let watch = (suffix, tasks) => {
 
 gulp.task('pug', () => glue('pug'));
 gulp.task('md', () => glue('md'));
+gulp.task('ejs', () => glue('ejs'));
 
 gulp.task('babel', () => {
   return gulp.src('src/**/*.js')
@@ -29,6 +30,7 @@ gulp.task('babel', () => {
 
 gulp.task('watch-babel', () => watch('js', ['babel']));
 gulp.task('watch-pug', () => watch('pug'));
+gulp.task('watch-ejs', () => watch('ejs'));
 gulp.task('watch-md', () => watch('md'));
 
 gulp.task('lint', () => {
@@ -38,6 +40,6 @@ gulp.task('lint', () => {
     .pipe(eslint.failAfterError());
 });
 
-gulp.task('build', ['lint', 'md', 'pug', 'babel']);
+gulp.task('build', ['lint', 'md', 'ejs', 'pug', 'babel']);
 
-gulp.task('dev', ['md', 'pug', 'babel', 'watch-md', 'watch-pug', 'watch-babel']);
+gulp.task('dev', ['md', 'pug', 'babel', 'watch-md', 'watch-ejs', 'watch-pug', 'watch-babel']);

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "change-case": "^3.0.0",
     "chokidar": "^1.6.1",
     "commander": "^2.9.0",
+    "ejs": "^2.5.2",
     "express": "^4.14.0",
     "fs-extra": "^0.30.0",
     "jsesc": "^2.2.0",

--- a/src/cli/cli-command.js
+++ b/src/cli/cli-command.js
@@ -45,9 +45,9 @@ export default class CliCommand {
         let ejsSrc = readFileSync(ejsPath, 'utf8');
         return ejs.render(ejsSrc, {
           loadFile: (p) => {
-            logger.debug('load path: ', p);
+            logger.silly('load path: ', p);
             let rel = resolve(join(dirname(ejsPath), p));
-            logger.debug('relative path: ', rel);
+            logger.silly('relative path: ', rel);
             return readFileSync(rel, 'utf8');
           }
         });

--- a/src/cli/cli-command.js
+++ b/src/cli/cli-command.js
@@ -1,7 +1,8 @@
-import path from 'path';
-import { readFileSync } from 'fs-extra';
+import { resolve, dirname, extname, join } from 'path';
+import { existsSync, readFileSync } from 'fs-extra';
 import _ from 'lodash';
 import { buildLogger } from '../log-factory';
+import ejs from 'ejs';
 
 const logger = buildLogger();
 
@@ -30,7 +31,7 @@ export default class CliCommand {
     let getMdFilename = () => {
       if (!usageValue) {
         return `${this.name}.md`;
-      } else if (path.extname(usageValue) === '.md') {
+      } else if (extname(usageValue) === '.md') {
         return usageValue;
       }
     }
@@ -38,7 +39,21 @@ export default class CliCommand {
     let mdFile = getMdFilename();
 
     if (mdFile) {
-      return readFileSync(path.join(__dirname, mdFile), { encoding: 'utf8' });
+      let mdPath = join(__dirname, mdFile);
+      let ejsPath = `${mdPath}.ejs`;
+      if (existsSync(ejsPath)) {
+        let ejsSrc = readFileSync(ejsPath, 'utf8');
+        return ejs.render(ejsSrc, {
+          loadFile: (p) => {
+            logger.debug('load path: ', p);
+            let rel = resolve(join(dirname(ejsPath), p));
+            logger.debug('relative path: ', rel);
+            return readFileSync(rel, 'utf8');
+          }
+        });
+      } else {
+        return readFileSync(mdPath, 'utf8');
+      }
     } else {
       return usageValue;
     }

--- a/src/cli/pack-question.md.ejs
+++ b/src/cli/pack-question.md.ejs
@@ -29,32 +29,4 @@ It generates 2 javascript files:
 pie-cli pack-question --dir ../path/to/dir
 ```
 
-#### Support 
-You can point to a js file to add support for a framework that has been added to a pie's `dependencies` object in the `package.json`.
-The module should (if it wants to support what's in the dependencies) an object that contains `npmDependencies : Object` and `webpackLoaders : (resolve) => Object`. Under the hood we use webpack to build the bundle and so these dependencies are what you'd use if you were doing your own webpack build.
-
-> Out of the box `pie-cli` has support for `react` and `less`.
-
-```javascript
-
-/**
- * @param dependencies - an object containing the dependency name and an array of versions:
- * { react: ['15.0.2'] }
- */
-export function support(dependencies){ 
-  if(!dependencies['my-cool-framework']){
-    return;
-  }
-
-  return {
-    /** return any dependencies that'll need to be added to support that framework when run against webpack.*/
-    npmDependencies: {},
-    /** return an array of loaders for the framework 
-     * @param resolve a function that will resolve the module (to be removed)
-     */
-    webpackLoaders: (resolve) => {
-      return [] 
-    }
-  };
-}
-```
+<%- loadFile('./support.md') %>

--- a/src/cli/serve-question.md.ejs
+++ b/src/cli/serve-question.md.ejs
@@ -3,7 +3,7 @@
 
 Run a server to serve this question. Any changes to the `pie` source code, the `config.json` or the `index.html` will be picked up. However if you add a new component to the `config.json` this won't be picked up, you'll have to restart the server.
 
-### Options
+## Options
   `--dir` - the relative path to a directory to use as the root. This should contain `config.json` and `index.html` (default: the current working directory)
   `--port` - the port to use - default `4000`
   `--clean` - clean build assets before serving. Do this if you've added a new component. default: `false`
@@ -15,37 +15,9 @@ Run a server to serve this question. Any changes to the `pie` source code, the `
   `--questionDependenciesFile` - the name of the pie data file - default `dependencies.json`
   `--questionMarkupFile` - the name of layout file - default `index.html`
   
-### Examples
+## Examples
 ```shell
 pie serve-question --dir ../path/to/dir
 ```
 
-#### Support 
-You can point to a js file to add support for a framework that has been added to a pie's `dependencies` object in the `package.json`.
-The module should (if it wants to support what's in the dependencies) an object that contains `npmDependencies : Object` and `webpackLoaders : (resolve) => Object`. Under the hood we use webpack to build the bundle and so these dependencies are what you'd use if you were doing your own webpack build.
-
-> Out of the box `pie-cli` has support for `react` and `less`.
-
-```javascript
-
-/**
- * @param dependencies - an object containing the dependency name and an array of versions:
- * { react: ['15.0.2'] }
- */
-export function support(dependencies){ 
-  if(!dependencies['my-cool-framework']){
-    return;
-  }
-
-  return {
-    /** return any dependencies that'll need to be added to support that framework when run against webpack.*/
-    npmDependencies: {},
-    /** return an array of loaders for the framework 
-     * @param resolve a function that will resolve the module (to be removed)
-     */
-    webpackLoaders: (resolve) => {
-      return [] 
-    }
-  };
-}
-```
+<%- loadFile('./support.md') %>

--- a/src/cli/support.md
+++ b/src/cli/support.md
@@ -1,0 +1,44 @@
+
+## Support 
+You can point to a js file to add support for a framework that has been added to a pie's `dependencies` object in the `package.json`.
+The module should (if it wants to support what's in the dependencies) an object that contains `npmDependencies : Object` and `webpackLoaders : (resolve) => Object`. Under the hood we use webpack to build the bundle and so these dependencies are what you'd use if you were doing your own webpack build.
+
+```javascript
+
+/**
+ * @param dependencies - an object containing the dependency name and an array of versions:
+ * { react: ['15.0.2'] }
+ */
+export function support(dependencies){ 
+  if(!dependencies['my-cool-framework']){
+    return;
+  }
+
+  return {
+    /** return any dependencies that'll need to be added to support that framework when run against webpack.*/
+    npmDependencies: {},
+    /** return an array of loaders for the framework 
+     * @param resolve a function that will resolve the module (to be removed)
+     */
+    webpackLoaders: (resolve) => {
+      return [] 
+    }
+  };
+}
+```
+### Existing support 
+
+Out of the box `pie-cli` has support for `react` and `less`. You don't need to add these to your support module.
+If you do you'll get errors.
+
+#### react 
+
+React uses the [babel-loader](https://github.com/babel/babel-loader) with  [babel-preset-react](https://github.com/babel/babel/tree/master/packages/babel-preset-react) enabled.
+
+#### less 
+
+See: [less-loader](https://github.com/webpack/less-loader).
+
+```javascript
+  require("!style!css!less!./file.less");
+```

--- a/src/code-gen/duplicate-loaders.js
+++ b/src/code-gen/duplicate-loaders.js
@@ -1,0 +1,77 @@
+import _ from 'lodash';
+import { buildLogger } from '../log-factory';
+import { Loader } from './loaders';
+
+const logger = buildLogger();
+
+let _getDuplicates = (config) => {
+
+  if (!config || !config.module || !config.module.loaders) {
+    return new DuplicateLoaders();
+  }
+
+  logger.silly('[removeDuplicateLoaders] config: ', JSON.stringify(config));
+
+  let c = _.cloneDeep(config);
+
+  c.module = c.module || { loaders: [] }
+
+  let loaderGroups = _.reduce(c.module.loaders, (acc, loader) => {
+
+    logger.silly('[removeDuplicateLoaders] acc: ', acc, ' loader:', loader);
+
+    let wrapped = new Loader(loader);
+    let name = wrapped.normalizedName;
+
+    if (acc[name]) {
+      acc[name].push(wrapped);
+    } else {
+      acc[name] = [wrapped];
+    }
+    return acc;
+  }, {});
+
+  return _.reduce(loaderGroups, (duplicates, loaderArray, key) => {
+
+    if (loaderArray.length === 0) {
+      throw new Error(`loader array for ${key} is empty - this should never happen`);
+    }
+
+    if (loaderArray.length > 1) {
+      duplicates.add(key, loaderArray);
+    }
+    return duplicates;
+
+  }, new DuplicateLoaders());
+}
+
+export default class DuplicateLoaders {
+
+  constructor() {
+    this._duplicates = {};
+  }
+
+  get error() {
+    let msg = `The following loaders are duplicated: ${_.keys(this._duplicates).join(', ')}`
+    return new Error(msg);
+  }
+
+  get present() {
+    return !_.isEmpty(this._duplicates);
+  }
+
+  static fromConfig(config) {
+    return _getDuplicates(config);
+  }
+
+  add(key, loaders) {
+    if (this._duplicates[key]) {
+      this._duplicates[key] = _.concat(this._duplicates[key], loaders);
+    } else {
+      let newLoaderMap = {};
+      newLoaderMap[key] = loaders;
+      this._duplicates = _.extend(this._duplicates, newLoaderMap);
+    }
+    return this;
+  }
+}

--- a/src/code-gen/loaders.js
+++ b/src/code-gen/loaders.js
@@ -1,0 +1,51 @@
+import { basename } from 'path';
+import querystring from 'querystring';
+import _ from 'lodash';
+
+export class Loader {
+  constructor(obj) {
+    this._raw = obj;
+    this._names = new LoaderNames(obj.loader);
+  }
+
+  get normalizedName() {
+    return this._names.normalizedStringName;
+  }
+}
+
+export class LoaderNames {
+
+  constructor(names) {
+    this._raw = names;
+    let [base, query] = names.split('?');
+    this._query = querystring.parse(query);
+    this._names = _.map(base.split('!'), n => new LoaderName(n))
+  }
+
+  get normalized() {
+    return _.map(this._names, n => n.normalized).join('!');
+  }
+
+  /**
+   * {a: 'A', b: 'b'}
+   */
+  get query() {
+    return this._query;
+  }
+}
+
+export class LoaderName {
+  constructor(n) {
+    this.name = n;
+  }
+  get normalized() {
+    let base = basename(this.name, '.js');
+    if (_.endsWith(base, '-loader')) {
+      return base;
+    } else {
+      return `${base}-loader`;
+    }
+  }
+}
+
+

--- a/src/code-gen/loaders.js
+++ b/src/code-gen/loaders.js
@@ -8,20 +8,6 @@ export class Loader {
     this._names = new LoaderNames(obj.loader);
   }
 
-  merge(other) {
-    if (!(other instanceof Loader)) {
-      throw new Error('this is not a loader');
-    }
-
-    if (other.normalizedName !== this.normalizedName) {
-      throw this.loadersDontMatchError(other);
-    }
-  }
-
-  loadersDontMatchError(other) {
-    return new Error(`only loaders of the same loader type can be merged this: ${this.normalizedName}, other: ${other.normalizedName}`);
-  }
-
   get normalizedName() {
     return this._names.normalized;
   }
@@ -61,5 +47,6 @@ export class LoaderName {
     }
   }
 }
+
 
 

--- a/src/code-gen/loaders.js
+++ b/src/code-gen/loaders.js
@@ -8,8 +8,22 @@ export class Loader {
     this._names = new LoaderNames(obj.loader);
   }
 
+  merge(other) {
+    if (!(other instanceof Loader)) {
+      throw new Error('this is not a loader');
+    }
+
+    if (other.normalizedName !== this.normalizedName) {
+      throw this.loadersDontMatchError(other);
+    }
+  }
+
+  loadersDontMatchError(other) {
+    return new Error(`only loaders of the same loader type can be merged this: ${this.normalizedName}, other: ${other.normalizedName}`);
+  }
+
   get normalizedName() {
-    return this._names.normalizedStringName;
+    return this._names.normalized;
   }
 }
 

--- a/src/code-gen/webpack-builder.js
+++ b/src/code-gen/webpack-builder.js
@@ -1,16 +1,148 @@
 import webpack from 'webpack';
 import { buildLogger } from '../log-factory';
 import _ from 'lodash';
+import { basename } from 'path';
+import querystring from 'querystring';
 
 const logger = buildLogger();
 
+
+class LoaderName {
+  constructor(n) {
+    this.name = n;
+  }
+  get normalized() {
+    let base = basename(this.name, '.js');
+    if (_.endsWith(base, '-loader')) {
+      return base;
+    } else {
+      return `${base}-loader`;
+    }
+  }
+}
+
+class Loader {
+  constructor(obj) {
+    this._raw = obj;
+    this._names = new LoaderNames(obj.loader);
+  }
+
+  get normalizedName() {
+    return this._names.normalizedStringName;
+  }
+}
+
+class LoaderNames {
+
+  constructor(names) {
+    this._raw = names;
+    let [base, query] = names.split('?');
+    this._query = querystring.parse(query);
+    this._names = _.map(base.split('!'), n => new LoaderName(n))
+  }
+
+  /**
+   * [l-loader,x-loader, ...]
+   */
+  get normalizedNames() {
+    return _.map(this._names, n => n.normalized);
+  }
+
+  get normalizedStringName() {
+    return this.normalizedNames.join('!');
+  }
+
+  /**
+   * {a: 'A', b: 'b'}
+   */
+  get query() {
+    return this._query;
+  }
+}
+
+function normalizeLoaderName(name) {
+  let base = basename(name, '.js');
+  if (_.endsWith(base, '-loader')) {
+    return base;
+  } else {
+    return `${base}-loader`;
+  }
+}
+
+function normalizeLoaderNames(names) {
+  let split = names.split('!');
+  return _.map(split, normalizeLoaderName).join('!')
+}
+
+function removeDuplicateLoaders(config) {
+
+  logger.silly('[removeDuplicateLoaders] config: ', JSON.stringify(config));
+
+  let c = _.cloneDeep(config);
+
+  c.module = c.module || { loaders: [] }
+
+  let loaderGroups = _.reduce(c.module.loaders, (acc, loader) => {
+
+    logger.silly('[removeDuplicateLoaders] acc: ', acc, ' loader:', loader);
+
+    let wrapped = new Loader(loader);
+    let name = wrapped.normalizedName;
+
+    /** 
+     * in webpack for a loader called 'less' the following are equal: 
+     * less == less-loader
+     */
+
+    if (acc[name]) {
+      acc[name].push(wrapped);
+    } else {
+      acc[name] = [wrapped];
+    }
+    return acc;
+  }, {});
+
+  let mergedGroups = _.reduce(loaderGroups, (acc, loaderArray, key) => {
+
+    if (loaderArray.length === 0) {
+      throw new Error(`loader array for ${key} is empty - this should never happen`);
+    }
+
+    let loader = _.reduce(_.tail(loaderArray), (acc, wrapped) => {
+      return acc.merge(wrapped);
+    }, _.head(loaderArray));
+
+    acc[key] = loader;
+    // let head = _.head(loaderArray);
+    // let rest = _.tail(loaderArray);
+
+    // acc.loaders.push(head);
+
+    // if (rest.length > 0) {
+    //   acc.duplicates[key] = acc.duplicates[key] || {}
+    //   acc.duplicates[key] = rest;
+    // }
+
+    return acc;
+
+  }, {});
+
+  logger.silly('[removeDuplicateLoaders] updatedConfig: ', c);
+
+  c.module.loaders = _(mergedGroups).values().map('webpackObject').value();
+  return c;
+}
+
 export function normalizeConfig(config) {
-  return config;
+  return removeDuplicateLoaders(config);
 }
 
 export function build(config) {
+
+  let normalized = normalizeConfig(config).normalized;
+
   return new Promise((resolve, reject) => {
-    webpack(config, (err, stats) => {
+    webpack(normalized, (err, stats) => {
       if (err) {
         logger.error(err.message);
         reject(err);

--- a/src/code-gen/webpack-builder.js
+++ b/src/code-gen/webpack-builder.js
@@ -4,6 +4,10 @@ import _ from 'lodash';
 
 const logger = buildLogger();
 
+export function normalizeConfig(config) {
+  return config;
+}
+
 export function build(config) {
   return new Promise((resolve, reject) => {
     webpack(config, (err, stats) => {

--- a/src/code-gen/webpack-builder.js
+++ b/src/code-gen/webpack-builder.js
@@ -1,148 +1,24 @@
 import webpack from 'webpack';
 import { buildLogger } from '../log-factory';
 import _ from 'lodash';
-import { basename } from 'path';
-import querystring from 'querystring';
+import DuplicateLoaders from './duplicate-loaders';
+import { configToJsString } from './webpack-write-config';
 
 const logger = buildLogger();
 
-
-class LoaderName {
-  constructor(n) {
-    this.name = n;
-  }
-  get normalized() {
-    let base = basename(this.name, '.js');
-    if (_.endsWith(base, '-loader')) {
-      return base;
-    } else {
-      return `${base}-loader`;
-    }
-  }
-}
-
-class Loader {
-  constructor(obj) {
-    this._raw = obj;
-    this._names = new LoaderNames(obj.loader);
-  }
-
-  get normalizedName() {
-    return this._names.normalizedStringName;
-  }
-}
-
-class LoaderNames {
-
-  constructor(names) {
-    this._raw = names;
-    let [base, query] = names.split('?');
-    this._query = querystring.parse(query);
-    this._names = _.map(base.split('!'), n => new LoaderName(n))
-  }
-
-  /**
-   * [l-loader,x-loader, ...]
-   */
-  get normalizedNames() {
-    return _.map(this._names, n => n.normalized);
-  }
-
-  get normalizedStringName() {
-    return this.normalizedNames.join('!');
-  }
-
-  /**
-   * {a: 'A', b: 'b'}
-   */
-  get query() {
-    return this._query;
-  }
-}
-
-function normalizeLoaderName(name) {
-  let base = basename(name, '.js');
-  if (_.endsWith(base, '-loader')) {
-    return base;
-  } else {
-    return `${base}-loader`;
-  }
-}
-
-function normalizeLoaderNames(names) {
-  let split = names.split('!');
-  return _.map(split, normalizeLoaderName).join('!')
-}
-
-function removeDuplicateLoaders(config) {
-
-  logger.silly('[removeDuplicateLoaders] config: ', JSON.stringify(config));
-
-  let c = _.cloneDeep(config);
-
-  c.module = c.module || { loaders: [] }
-
-  let loaderGroups = _.reduce(c.module.loaders, (acc, loader) => {
-
-    logger.silly('[removeDuplicateLoaders] acc: ', acc, ' loader:', loader);
-
-    let wrapped = new Loader(loader);
-    let name = wrapped.normalizedName;
-
-    /** 
-     * in webpack for a loader called 'less' the following are equal: 
-     * less == less-loader
-     */
-
-    if (acc[name]) {
-      acc[name].push(wrapped);
-    } else {
-      acc[name] = [wrapped];
-    }
-    return acc;
-  }, {});
-
-  let mergedGroups = _.reduce(loaderGroups, (acc, loaderArray, key) => {
-
-    if (loaderArray.length === 0) {
-      throw new Error(`loader array for ${key} is empty - this should never happen`);
-    }
-
-    let loader = _.reduce(_.tail(loaderArray), (acc, wrapped) => {
-      return acc.merge(wrapped);
-    }, _.head(loaderArray));
-
-    acc[key] = loader;
-    // let head = _.head(loaderArray);
-    // let rest = _.tail(loaderArray);
-
-    // acc.loaders.push(head);
-
-    // if (rest.length > 0) {
-    //   acc.duplicates[key] = acc.duplicates[key] || {}
-    //   acc.duplicates[key] = rest;
-    // }
-
-    return acc;
-
-  }, {});
-
-  logger.silly('[removeDuplicateLoaders] updatedConfig: ', c);
-
-  c.module.loaders = _(mergedGroups).values().map('webpackObject').value();
-  return c;
-}
-
-export function normalizeConfig(config) {
-  return removeDuplicateLoaders(config);
-}
-
 export function build(config) {
 
-  let normalized = normalizeConfig(config).normalized;
+  let duplicates = DuplicateLoaders.fromConfig(config);
+
+  if (duplicates.present) {
+
+    logger.error('This config has duplicate loaders:');
+    logger.error(configToJsString(config));
+    return Promise.reject(duplicates.error)
+  }
 
   return new Promise((resolve, reject) => {
-    webpack(normalized, (err, stats) => {
+    webpack(config, (err, stats) => {
       if (err) {
         logger.error(err.message);
         reject(err);

--- a/test/unit/code-gen/duplicate-loaders-test.js
+++ b/test/unit/code-gen/duplicate-loaders-test.js
@@ -1,0 +1,62 @@
+import { expect } from 'chai';
+import { buildLogger } from '../../../src/log-factory';
+const logger = buildLogger();
+
+describe('duplicate-loaders', () => {
+
+  let DuplicateLoaders, config;
+
+  beforeEach(() => {
+    config = {
+      module: {
+        loaders: [
+          { loader: 'a!b' },
+          { loader: 'a!b' }
+        ]
+      }
+    }
+
+    DuplicateLoaders = require('../../../src/code-gen/duplicate-loaders').default;
+  });
+
+  describe('fromConfig', () => {
+
+    it('returns duplicates w/ present=false for undefined config', () => {
+      expect(DuplicateLoaders.fromConfig().present).to.eql(false);
+    });
+
+    it('returns duplicates w/ present=false for empty config.module', () => {
+      expect(DuplicateLoaders.fromConfig({}).present).to.eql(false);
+    });
+
+    it('returns duplicates w/ present=false for an empty config.module.loaders', () => {
+      expect(DuplicateLoaders.fromConfig({ module: {} }).present).to.eql(false);
+    });
+
+    it('returns duplicates w/ present=true for a config', () => {
+      let duplicates = DuplicateLoaders.fromConfig(config);
+      logger.debug('duplicates: ', duplicates);
+      expect(duplicates.present).to.eql(true);
+    });
+  });
+
+  describe('present', () => {
+    it('returns false for an new instance', () => {
+      expect(new DuplicateLoaders().present).to.eql(false);
+    });
+
+    it('returns true an instance with a duplicate added', () => {
+      let duplicates = new DuplicateLoaders();
+      duplicates.add('a', [{ loader: 'a' }, { loader: 'a-loader' }]);
+      expect(duplicates.present).to.eql(true);
+    });
+  });
+
+  describe('error', () => {
+    it('returns an error', () => {
+      let duplicates = new DuplicateLoaders();
+      duplicates.add('a', [{ loader: 'a' }, { loader: 'a-loader' }]);
+      expect(duplicates.error.message).to.eql('The following loaders are duplicated: a');
+    });
+  });
+});

--- a/test/unit/code-gen/loader-test.js
+++ b/test/unit/code-gen/loader-test.js
@@ -59,7 +59,19 @@ describe('loaders', () => {
     describe('merge', () => {
       it('throws an error if the loaders do not match', () => {
 
-        let one = new mod.Loader()
+        let one = new mod.Loader({
+          test: /\.less$/,
+          loader: 'less'
+        });
+
+        let two = new mod.Loader({
+          test: /\.css$/,
+          loader: 'css'
+        });
+
+        expect(() => {
+          one.merge(two)
+        }).to.throw(one.loadersDontMatchError(two).message);
       });
     });
   });

--- a/test/unit/code-gen/loader-test.js
+++ b/test/unit/code-gen/loader-test.js
@@ -35,43 +35,15 @@ describe('loaders', () => {
       it('returns 2 names', () => {
         expect(new mod.LoaderNames('a!b').normalized).to.eql('a-loader!b-loader');
       });
-
-
-    });
-
-    describe('query', () => {
-
-      it('returns an empty query object', () => {
-        expect(new mod.LoaderNames('a').query).to.eql({});
-      });
-
-      it('returns a query object', () => {
-        expect(new mod.LoaderNames('a?foo=bar&baz=moo').query).to.eql({
-          foo: 'bar',
-          baz: 'moo'
-        });
-      });
     });
   });
 
   describe('Loader', () => {
 
-    describe('merge', () => {
-      it('throws an error if the loaders do not match', () => {
+    describe('normalizedName', () => {
 
-        let one = new mod.Loader({
-          test: /\.less$/,
-          loader: 'less'
-        });
-
-        let two = new mod.Loader({
-          test: /\.css$/,
-          loader: 'css'
-        });
-
-        expect(() => {
-          one.merge(two)
-        }).to.throw(one.loadersDontMatchError(two).message);
+      it('returns the name', () => {
+        expect(new mod.Loader({ loader: 'a!b!c' }).normalizedName).to.eql('a-loader!b-loader!c-loader')
       });
     });
   });

--- a/test/unit/code-gen/loader-test.js
+++ b/test/unit/code-gen/loader-test.js
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+
+describe('loaders', () => {
+
+  let mod;
+
+  beforeEach(() => {
+    mod = proxyquire('../../../src/code-gen/loaders', {});
+  });
+
+  describe('LoaderName', () => {
+
+    describe('normalized', () => {
+      it('normalizes the short name', () => {
+        expect(new mod.LoaderName('a').normalized).to.eql('a-loader');
+      });
+
+      it('normalizes the resolved name', () => {
+        expect(new mod.LoaderName('path/to/a.js').normalized).to.eql('a-loader');
+      });
+      it('does not normalize the normalized name', () => {
+        expect(new mod.LoaderName('a-loader').normalized).to.eql('a-loader');
+      });
+    });
+  });
+
+  describe('LoaderNames', () => {
+
+    describe('normalized', () => {
+      it('returns 1 names', () => {
+        expect(new mod.LoaderNames('a').normalized).to.eql('a-loader');
+      });
+
+      it('returns 2 names', () => {
+        expect(new mod.LoaderNames('a!b').normalized).to.eql('a-loader!b-loader');
+      });
+
+
+    });
+
+    describe('query', () => {
+
+      it('returns an empty query object', () => {
+        expect(new mod.LoaderNames('a').query).to.eql({});
+      });
+
+      it('returns a query object', () => {
+        expect(new mod.LoaderNames('a?foo=bar&baz=moo').query).to.eql({
+          foo: 'bar',
+          baz: 'moo'
+        });
+      });
+    });
+  });
+
+  describe('Loader', () => {
+
+    describe('merge', () => {
+      it('throws an error if the loaders do not match', () => {
+
+        let one = new mod.Loader()
+      });
+    });
+  });
+
+});

--- a/test/unit/code-gen/webpack-builder-test.js
+++ b/test/unit/code-gen/webpack-builder-test.js
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+import _ from 'lodash';
+import { stub, spy } from 'sinon';
+
+describe('webpack-builder', () => {
+
+  let mod, stats;
+  beforeEach(() => {
+
+    stats = {
+      hasError: stub().returns(false)
+    }
+
+    mod = proxyquire('../../../src/code-gen/webpack-builder', {
+      webpack: spy((config, done) => {
+        done(null, stats);
+      })
+    })
+  });
+
+  describe('normalizeConfig', () => {
+
+    it('removes duplicate loaders', () => {
+
+      let config = {
+        module: {
+          loaders: [
+            { loader: 'less', test: /\.less$/ },
+            { loader: 'less', test: /\.less$/ }
+          ]
+        }
+      }
+
+      let expected = _.cloneDeep(config);
+      expected.module.loaders.splice(1);
+      expect(mod.normalizeConfig(config)).to.eql({});
+    });
+  });
+});

--- a/test/unit/code-gen/webpack-builder-test.js
+++ b/test/unit/code-gen/webpack-builder-test.js
@@ -13,7 +13,7 @@ describe('webpack-builder', () => {
     }
 
     mod = proxyquire('../../../src/code-gen/webpack-builder', {
-      webpack: spy((config, done) => {
+      webpack: spy(function (config, done) {
         done(null, stats);
       })
     })
@@ -34,7 +34,7 @@ describe('webpack-builder', () => {
 
       let expected = _.cloneDeep(config);
       expected.module.loaders.splice(1);
-      expect(mod.normalizeConfig(config)).to.eql({});
+      expect(mod.normalizeConfig(config)).to.eql(expected);
     });
   });
 });


### PR DESCRIPTION
having duplicate loaders results in a webpack error. if the version range is compatible then use the latest version and conflate. if the version range isn't compatible throw an error.