### PR TITLE
add schema validator for config.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
+    "ajv": "^4.8.2",
     "babel-core": "^6.16.0",
     "babel-loader": "^6.2.5",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",

--- a/src/question/client/index.js
+++ b/src/question/client/index.js
@@ -69,6 +69,11 @@ export class ClientBuildable {
     let step = clean ? this.clean() : Promise.resolve();
     return step
       .then(() => this._install())
+      .then(() => {
+        let isValid = this.config.isConfigValid();
+        logger.silly('isConfigValid() ? ', isValid)
+        return isValid ? Promise.resolve() : Promise.reject('config is invalid');
+      })
       .then(() => this.writeEntryJs())
       .then(() => this.webpackConfig());
   }
@@ -143,7 +148,7 @@ export class ClientBuildable {
     logger.silly('[_buildFrameworkConfig] appDependencyKeys: ', appDependencyKeys);
     let appPackages = this.config.readPackages(appDependencyKeys);
     logger.silly('[_buildFrameworkConfig] appPackages: ', appPackages);
-    let allPackages = _.concat( this.config.piePackages, appPackages);
+    let allPackages = _.concat(this.config.piePackages, appPackages);
     logger.silly('[_buildFrameworkConfig] allPackages: ', allPackages);
 
     let merged = _(allPackages).map('dependencies').reduce(mergeDependencies, {});

--- a/src/question/config-validator.js
+++ b/src/question/config-validator.js
@@ -1,0 +1,51 @@
+import Ajv from 'ajv';
+
+const schema = {
+  title: 'config.json',
+  description: 'The schema for a question config',
+  type: 'object',
+  properties: {
+    pies: {
+      type: 'array',
+      minItems: 1,
+      items: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string'
+          },
+          pie: {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string'
+              },
+              version: {
+                type: 'string'
+              }
+            },
+            required: [
+              'name',
+              'version'
+            ]
+          }
+        },
+        required: [
+          'pie', 'id'
+        ]
+      }
+    }
+  },
+  required: [
+    'pies'
+  ]
+};
+
+const ajv = new Ajv();
+
+const validateFn = ajv.compile(schema);
+
+export function validate(config) {
+  var valid = validateFn(config);
+  return { valid: valid, errors: validateFn.errors || [] }
+}

--- a/src/question/config-validator.js
+++ b/src/question/config-validator.js
@@ -1,4 +1,8 @@
 import Ajv from 'ajv';
+import _ from 'lodash';
+import { buildLogger } from '../log-factory';
+
+const logger = buildLogger();
 
 const schema = {
   title: 'config.json',
@@ -45,7 +49,59 @@ const ajv = new Ajv();
 
 const validateFn = ajv.compile(schema);
 
-export function validate(config) {
-  var valid = validateFn(config);
-  return { valid: valid, errors: validateFn.errors || [] }
+/**
+ * A cache of schema validation functions
+ */
+const schemaValidators = {};
+
+function emptyValidate() {
+  return true;
+}
+
+emptyValidate.errors = [];
+
+function validatePie(loadSchema, obj) {
+  logger.silly('[validatePie]', obj);
+  let name = obj.pie.name;
+  if (!schemaValidators[name]) {
+    let schema = loadSchema(name);
+    schemaValidators[name] = schema ? ajv.compile(schema) : emptyValidate;
+  }
+  let valid = schemaValidators[name](obj);
+  return {
+    valid: valid,
+    errors: schemaValidators[name].errors,
+    id: obj.id
+  }
+}
+
+/** 
+ * TODO: For all pie libs referenced in the config
+ * Try to find a schema for it and then validate that node against the schema
+ */
+export function validate(config, loadSchema) {
+
+  loadSchema = loadSchema || (() => null);
+
+  let baseValid = validateFn(config);
+
+  if (baseValid) {
+    let pieValidations = _.map(config.pies, validatePie.bind(null, loadSchema));
+    let pieValidationsAllValid = _.filter(pieValidations, v => !v.valid).length === 0;
+    let valid = baseValid && pieValidationsAllValid;
+
+    logger.silly(`[validate] baseValid: ${baseValid}`);
+    logger.silly(`[validate] pieValidationsAllValid: ${pieValidationsAllValid}`);
+
+    return {
+      valid: valid,
+      errors: validateFn.errors || [],
+      pies: pieValidations
+    }
+  } else {
+    return {
+      valid: false,
+      errors: validateFn.errors
+    }
+  }
 }

--- a/src/question/question-config.js
+++ b/src/question/question-config.js
@@ -45,6 +45,7 @@ export class QuestionConfig {
   }
 
   readConfig() {
+    //todo - add error check here...
     return this._readJson(this.filenames.config);
   }
 

--- a/src/question/question-config.js
+++ b/src/question/question-config.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { buildLogger } from '../log-factory';
 import fs from 'fs-extra';
 import { join } from 'path';
+import { validate as validateConfig } from './config-validator';
 
 const logger = buildLogger();
 
@@ -60,7 +61,14 @@ export class QuestionConfig {
   }
 
   readConfig() {
-    return this._readJson(this.filenames.config, `failed to load the configuration file: ${this.filenames.config}`);
+    let json = this._readJson(this.filenames.config, `failed to load the configuration file: ${this.filenames.config}`);
+    let result = validateConfig(json);
+    if (result.valid) {
+      return json;
+    } else {
+      logger.error(`config.json validation.errors: ${JSON.stringify(result.errors, null, '  ')}`);
+      throw new Error('config.json has an invalid schema');
+    }
   }
 
 

--- a/test/integration/example-components/hello-world/docs/schemas/config.json
+++ b/test/integration/example-components/hello-world/docs/schemas/config.json
@@ -1,0 +1,13 @@
+{
+  "title": "hello world config schema",
+  "description": "The schema for hello-world",
+  "type": "object",
+  "properties": {
+    "prompt": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "prompt"
+  ]
+}

--- a/test/integration/example-questions/hello-world-with-bad-config-model/config.json
+++ b/test/integration/example-questions/hello-world-with-bad-config-model/config.json
@@ -1,0 +1,12 @@
+{
+  "pies": [
+    {
+      "id": "1",
+      "pie": {
+        "name": "hello-world",
+        "version": "~1.0.0"
+      },
+      "my-prompt": "hi"
+    }
+  ]
+}

--- a/test/integration/example-questions/hello-world-with-bad-config-model/dependencies.json
+++ b/test/integration/example-questions/hello-world-with-bad-config-model/dependencies.json
@@ -1,0 +1,3 @@
+{
+  "hello-world": "../../example-components/hello-world"
+}

--- a/test/integration/example-questions/hello-world-with-bad-config-model/index.html
+++ b/test/integration/example-questions/hello-world-with-bad-config-model/index.html
@@ -1,0 +1,1 @@
+<hello-world pie-id="1"></hello-world>

--- a/test/integration/question/question-config-test.js
+++ b/test/integration/question/question-config-test.js
@@ -1,50 +1,77 @@
-import QuestionConfig from '../../../src/question/question-config';
+import { QuestionConfig } from '../../../src/question/question-config';
+import NpmDir from '../../../src/npm/npm-dir';
 import { expect } from 'chai';
-import temp from 'temp';
-import fs from 'fs-extra';
-import path from 'path';
+import { join } from 'path';
+import { setUpTmpQuestionAndComponents } from '../integration-test-helper';
 
 describe('Question', () => {
 
-  let config;
-  let sampleQuestion = path.resolve(path.join(__dirname, '..', 'example-questions', 'one'));
-  let helloWorld = path.resolve(path.join(__dirname, '..', 'example-components', 'hello-world'));
-  let tmpPath, tmpNodeModules;
+  describe('question one', () => {
+    let config, questionPath, npmDir;
 
-  before(() => {
-    tmpPath = temp.mkdirSync('question-test');
-    tmpNodeModules = path.join(tmpPath, 'node_modules');
-    console.log('tmpNodeModules: ', tmpNodeModules);
-    fs.ensureDirSync(tmpNodeModules);
-    //pretend to install hello-world
-    fs.copySync(helloWorld, path.join(tmpNodeModules, 'hello-world'));
-    fs.copySync(sampleQuestion, tmpPath);
-    config = new QuestionConfig(tmpPath);
-  });
-
-  describe('pies', () => {
-    it('returns pies', () => {
-      expect(config.pies).to.eql([{
-        installedPath: path.join(tmpPath, 'node_modules/hello-world'),
-        localPath: '../../example-components/hello-world',
-        name: 'hello-world',
-        versions: ['~1.0.0']
-      }]);
+    before(() => {
+      let tmpPath = setUpTmpQuestionAndComponents('question-test');
+      questionPath = join(tmpPath, 'example-questions', 'one');
+      config = new QuestionConfig(questionPath);
+      npmDir = new NpmDir(questionPath);
     });
-  });
 
-  describe('npm-dependencies', () => {
+    describe('pies', () => {
+      it('returns pies', () => {
+        expect(config.pies).to.eql([{
+          installedPath: join(questionPath, 'node_modules/hello-world'),
+          localPath: '../../example-components/hello-world',
+          name: 'hello-world',
+          versions: ['~1.0.0']
+        }]);
+      });
+    });
 
-    it('returns the dependencies', () => {
-      expect(config.npmDependencies).to.eql({
-        'hello-world': '../../example-components/hello-world'
+    describe('npm-dependencies', () => {
+
+      it('returns the dependencies', () => {
+        expect(config.npmDependencies).to.eql({
+          'hello-world': '../../example-components/hello-world'
+        });
+      });
+    });
+
+    describe('piePackages', function () {
+
+      this.timeout(60000);
+
+      before((done) => {
+        npmDir.install(config.npmDependencies)
+          .then(() => done())
+          .catch(done);
+      });
+
+      it('returns the name of the first package object', () => {
+        expect(config.piePackages[0].name).to.eql('hello-world');
       });
     });
   });
 
-  describe('piePackages', () => {
-    it('returns the name of the first package object', () => {
-      expect(config.piePackages[0].name).to.eql('hello-world');
-    })
+  describe('hello-world-with-bad-config-model', () => {
+
+    let questionPath, config, npmDir;
+
+    before(function (done) {
+      this.timeout(60000);
+      let tmpPath = setUpTmpQuestionAndComponents('with-bad-config');
+      questionPath = join(tmpPath, 'example-questions', 'hello-world-with-bad-config-model');
+      config = new QuestionConfig(questionPath);
+      npmDir = new NpmDir(questionPath);
+      npmDir.install(config.npmDependencies)
+        .then(() => done())
+        .catch(done);
+    });
+
+    describe('isConfigValid', () => {
+      it.only('returns false', () => {
+        expect(config.isConfigValid()).to.eql(false);
+      });
+    });
+
   });
 });

--- a/test/unit/question/client/index-test.js
+++ b/test/unit/question/client/index-test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
-import sinon from 'sinon';
+import { assert, stub, spy } from 'sinon';
 import _ from 'lodash';
 
 describe('client', () => {
@@ -9,20 +9,20 @@ describe('client', () => {
   beforeEach(() => {
 
     emptyApp = {
-      frameworkSupport: sinon.stub().returns([]),
+      frameworkSupport: stub().returns([]),
       dependencies: () => []
     }
 
     npmDirInstance = {
-      clean: sinon.stub().returns(Promise.resolve())
+      clean: stub().returns(Promise.resolve())
     };
 
-    npmDirConstructor = sinon.stub().returns(npmDirInstance);
+    npmDirConstructor = stub().returns(npmDirInstance);
 
-    removeFiles = sinon.stub().returns(Promise.resolve());
+    removeFiles = stub().returns(Promise.resolve());
 
     frameworkSupport = {
-      bootstrap: sinon.stub().returns(frameworkSupport)
+      bootstrap: stub().returns(frameworkSupport)
     };
 
     index = proxyquire('../../../../src/question/client', {
@@ -69,7 +69,7 @@ describe('client', () => {
       });
 
       it('calls new NpmDir', () => {
-        sinon.assert.calledWith(npmDirConstructor, 'dir');
+        assert.calledWith(npmDirConstructor, 'dir');
       });
 
     });
@@ -84,11 +84,11 @@ describe('client', () => {
       });
 
       it('calls npmDir.clean', () => {
-        sinon.assert.called(npmDirInstance.clean);
+        assert.called(npmDirInstance.clean);
       });
 
       it('calls removeFile', () => {
-        sinon.assert.calledWith(removeFiles, 'dir', ['pie.js', 'pie.js.map', 'entry.js']);
+        assert.calledWith(removeFiles, 'dir', ['pie.js', 'pie.js.map', 'entry.js']);
       });
     });
 
@@ -96,16 +96,16 @@ describe('client', () => {
       let buildable;
       beforeEach(() => {
         buildable = new ClientBuildable({ dir: 'dir' }, [], { bundleName: 'pie.js' }, emptyApp);
-        buildable.prepareWebpackConfig = sinon.stub().returns(Promise.resolve());
-        buildable.bundle = sinon.stub().returns(Promise.resolve());
+        buildable.prepareWebpackConfig = stub().returns(Promise.resolve());
+        buildable.bundle = stub().returns(Promise.resolve());
       });
 
       let pack = (clean) => {
         return (done) => {
           buildable.pack(clean)
             .then(() => {
-              sinon.assert.calledWith(buildable.prepareWebpackConfig, clean);
-              sinon.assert.called(buildable.bundle);
+              assert.calledWith(buildable.prepareWebpackConfig, clean);
+              assert.called(buildable.bundle);
               done();
             })
             .catch(done);
@@ -120,20 +120,22 @@ describe('client', () => {
       let buildable;
       beforeEach(() => {
         buildable = new ClientBuildable({ dir: 'dir' }, [], { bundleName: 'pie.js' }, emptyApp);
-        buildable.clean = sinon.stub().returns(Promise.resolve());
-        buildable._install = sinon.stub().returns(Promise.resolve());
-        buildable.writeEntryJs = sinon.stub().returns(Promise.resolve());
-        buildable.webpackConfig = sinon.stub().returns(Promise.resolve());
+        buildable.clean = stub().returns(Promise.resolve());
+        buildable._install = stub().returns(Promise.resolve());
+        buildable.writeEntryJs = stub().returns(Promise.resolve());
+        buildable.webpackConfig = stub().returns(Promise.resolve());
+        buildable.config.isConfigValid = stub().returns(true);
       });
 
       let prepareWebpackConfig = (clean) => {
         return (done) => {
           buildable.prepareWebpackConfig(clean)
             .then(() => {
-              sinon.assert.called(buildable._install);
-              sinon.assert.called(buildable.writeEntryJs);
-              sinon.assert.called(buildable.webpackConfig);
-              sinon.assert[clean ? 'called' : 'notCalled'](buildable.clean);
+              assert.called(buildable._install);
+              assert.called(buildable.writeEntryJs);
+              assert.called(buildable.webpackConfig);
+              assert[clean ? 'called' : 'notCalled'](buildable.clean);
+              assert.called(buildable.config.isConfigValid);
               done();
             })
             .catch(done);
@@ -160,20 +162,20 @@ describe('client', () => {
               }
             }
           ],
-          readPackages: sinon.spy(keys => {
+          readPackages: spy(keys => {
             return _.map(keys, k => {
-              let o = { dependencies: {}}
+              let o = { dependencies: {} }
               o.dependencies[k] = '1.0.0';
               return o;
             });
           })
         };
 
-        emptyApp.dependencies = sinon.stub().returns({appDependency: '1.0.0'});
+        emptyApp.dependencies = stub().returns({ appDependency: '1.0.0' });
 
         buildable = new ClientBuildable(config, [], { bundleName: 'pie.js', pieBranch: 'develop' }, emptyApp);
         buildable.frameworkSupport = {
-          buildConfigFromPieDependencies: sinon.stub().returns({ _mockSupportConfig: true })
+          buildConfigFromPieDependencies: stub().returns({ _mockSupportConfig: true })
         }
 
         buildable._buildFrameworkConfig()
@@ -184,7 +186,7 @@ describe('client', () => {
       });
 
       it('calls buildConfigFromPieDependencies', () => {
-        sinon.assert.calledWith(buildable.frameworkSupport.buildConfigFromPieDependencies, { a: ['1.0.0'],  b: ['1.0.0'], appDependency: ['1.0.0'] });
+        assert.calledWith(buildable.frameworkSupport.buildConfigFromPieDependencies, { a: ['1.0.0'], b: ['1.0.0'], appDependency: ['1.0.0'] });
       });
 
       it('sets _supportConfig', () => {
@@ -192,7 +194,7 @@ describe('client', () => {
       });
 
       it('call app.dependencies with pieBranch', () => {
-        sinon.assert.calledWith(emptyApp.dependencies, 'develop');
+        assert.calledWith(emptyApp.dependencies, 'develop');
       })
     });
 
@@ -206,7 +208,7 @@ describe('client', () => {
 
         buildable = new ClientBuildable({ dir: 'dir' }, [], { bundleName: 'pie.js' }, emptyApp);
         buildable._supportConfig = {
-          webpackLoaders: sinon.stub().returns([loader])
+          webpackLoaders: stub().returns([loader])
         }
         buildable.webpackConfig()
           .then((c) => {
@@ -217,7 +219,7 @@ describe('client', () => {
       });
 
       it('calls webpackLoaders', () => {
-        sinon.assert.called(buildable._supportConfig.webpackLoaders);
+        assert.called(buildable._supportConfig.webpackLoaders);
       });
 
       it('returns config.context', () => {

--- a/test/unit/question/config-validator-test.js
+++ b/test/unit/question/config-validator-test.js
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { buildLogger } from '../../../src/log-factory';
+
+const logger = buildLogger();
+
+describe('config-validator', () => {
+  let validate = require('../../../src/question/config-validator').validate;
+
+
+  let assertValid = (obj, expected) => {
+    it(`returns ${expected} for an empty ${JSON.stringify(obj)}`, () => {
+      let result = validate(obj);
+      logger.debug('result: ', JSON.stringify(result));
+      expect(result.valid).to.eql(expected);
+    });
+  }
+
+  assertValid({}, false);
+  assertValid({ pies: [] }, false);
+  assertValid({ pies: [{ id: '1' }] }, false);
+  assertValid({ pies: [{ pie: { name: 'name', version: 'version' } }] }, false);
+  assertValid({ pies: [{ id: '1', pie: { name: 'name', version: 'version' } }] }, true);
+
+
+});

--- a/test/unit/question/config-validator-test.js
+++ b/test/unit/question/config-validator-test.js
@@ -1,25 +1,89 @@
 import { expect } from 'chai';
 import { buildLogger } from '../../../src/log-factory';
+import _ from 'lodash';
 
 const logger = buildLogger();
 
 describe('config-validator', () => {
   let validate = require('../../../src/question/config-validator').validate;
 
+  describe('validate', () => {
 
-  let assertValid = (obj, expected) => {
-    it(`returns ${expected} for an empty ${JSON.stringify(obj)}`, () => {
-      let result = validate(obj);
-      logger.debug('result: ', JSON.stringify(result));
-      expect(result.valid).to.eql(expected);
-    });
-  }
+    let assertValid = (obj, expected) => {
+      it(`returns ${expected} for an empty ${JSON.stringify(obj)}`, () => {
+        let result = validate(obj);
+        logger.debug('result: ', JSON.stringify(result));
+        expect(result.valid).to.eql(expected);
+      });
+    }
 
-  assertValid({}, false);
-  assertValid({ pies: [] }, false);
-  assertValid({ pies: [{ id: '1' }] }, false);
-  assertValid({ pies: [{ pie: { name: 'name', version: 'version' } }] }, false);
-  assertValid({ pies: [{ id: '1', pie: { name: 'name', version: 'version' } }] }, true);
+    assertValid({}, false);
+    assertValid({ pies: [] }, false);
+    assertValid({ pies: [{ id: '1' }] }, false);
+    assertValid({ pies: [{ pie: { name: 'name', version: 'version' } }] }, false);
+    assertValid({ pies: [{ id: '1', pie: { name: 'name', version: 'version' } }] }, true);
+  });
+
+  describe('validate w/ pie schemas for individual pies', () => {
+
+    let data, pieSchema, correctData;
 
 
+    pieSchema = {
+      title: 'test pie schema',
+      type: 'object',
+      properties: {
+        prompt: {
+          type: 'string'
+        },
+        answer: {
+          type: 'string'
+        }
+      },
+      required: ['prompt', 'answer']
+    }
+
+    data = {
+      pies: [
+        {
+          id: '1',
+          pie: { name: 'my-pie', version: '1.0.0' },
+          prompt: 'What is 1 + 1',
+          answer: '2'
+        },
+        {
+          id: '2',
+          pie: { name: 'my-pie', version: '1.0.0' },
+          answer: '3'
+        }
+      ]
+    }
+
+    correctData = _.cloneDeep(data);
+    correctData.pies[1].prompt = 'fixed prompt';
+
+    let assertValid = (obj, expected, failingId) => {
+      let result;
+
+      describe(`with ${JSON.stringify(obj)}`, () => {
+        beforeEach(() => {
+          result = validate(obj, () => pieSchema);
+          logger.debug(result);
+        });
+
+        it(`returns ${expected} for ${JSON.stringify(obj)}`, () => {
+          expect(result.valid).to.eql(expected);
+        });
+
+        it(`failing id is ${failingId}`, () => {
+          if (!result.valid) {
+            expect(result.failingPieValidations[0].id).to.eql(failingId);
+          }
+        });
+      });
+    }
+
+    assertValid(data, false, '2');
+    assertValid(correctData, true);
+  });
 });

--- a/test/unit/question/question-config-test.js
+++ b/test/unit/question/question-config-test.js
@@ -2,6 +2,9 @@ import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { stub } from 'sinon';
 import { join } from 'path';
+import { buildLogger } from '../../../src/log-factory';
+const logger = buildLogger();
+
 
 
 describe('QuestionConfig', () => {
@@ -43,7 +46,8 @@ describe('QuestionConfig', () => {
       expect(BuildOpts.build()).to.eql({
         config: 'config.json',
         dependencies: 'dependencies.json',
-        markup: 'index.html'
+        markup: 'index.html',
+        schemasDir: 'docs/schemas'
       });
     });
 
@@ -51,7 +55,8 @@ describe('QuestionConfig', () => {
       expect(BuildOpts.build({})).to.eql({
         config: 'config.json',
         dependencies: 'dependencies.json',
-        markup: 'index.html'
+        markup: 'index.html',
+        schemasDir: 'docs/schemas'
       });
     });
 
@@ -59,11 +64,13 @@ describe('QuestionConfig', () => {
       expect(BuildOpts.build({
         'questionConfigFile': 'c.json',
         'questionDependenciesFile': 'd.json',
-        'questionMarkupFile': 'i.html'
+        'questionMarkupFile': 'i.html',
+        'questionSchemasDir': 'docs/my-schemas'
       })).to.eql({
         config: 'c.json',
         dependencies: 'd.json',
-        markup: 'i.html'
+        markup: 'i.html',
+        schemasDir: 'docs/my-schemas'
       });
     })
   });
@@ -82,10 +89,6 @@ describe('QuestionConfig', () => {
     });
 
 
-    it('throws an error if the dir does not contain a config.json', () => {
-      fsExtra.readJsonSync.throws(new Error('config.json'));
-      expect(() => new proxy.QuestionConfig(__dirname, new BuildOpts())).to.throw(Error, proxy.QuestionConfig.fileError('config.json'));
-    });
 
     it('throws an error if the dir does not contain a dependencies.json', () => {
       fsExtra.readJsonSync.withArgs(join(__dirname, 'dependencies.json')).throws(new Error('dependencies.json'));
@@ -93,11 +96,6 @@ describe('QuestionConfig', () => {
         .to.throw(Error, proxy.QuestionConfig.fileError('dependencies.json'));
     });
 
-    it('throws an error if markup file can not be found', () => {
-      fsExtra.readFileSync.withArgs(join(__dirname, 'index.html')).throws(new Error('!!'));
-      expect(() => new (proxy.QuestionConfig)(__dirname, new BuildOpts()))
-        .to.throw(Error, proxy.QuestionConfig.fileError('index.html'));
-    });
 
     it('not throw an error if the dir contains config.json + dependencies.json', () => {
       expect(() => new proxy.QuestionConfig(__dirname, new BuildOpts()))
@@ -131,6 +129,23 @@ describe('QuestionConfig', () => {
       }
       fsExtra.readJsonSync.withArgs(join(__dirname, 'config.json')).returns(config);
       fsExtra.readJsonSync.withArgs(join(__dirname, 'dependencies.json')).returns(dependencies);
+    });
+
+    describe('get config', () => {
+      it('throws an error if the dir does not contain a config.json', () => {
+        fsExtra.readJsonSync.withArgs(join(__dirname, 'config.json')).throws(new Error('config.json'));
+        let config = new proxy.QuestionConfig(__dirname, new BuildOpts());
+        expect(() => config.config).to.throw(Error, proxy.QuestionConfig.fileError('config.json'));
+      });
+    });
+
+    describe('get markup', () => {
+
+      it('throws an error if markup file cant be found', () => {
+        fsExtra.readFileSync.withArgs(join(__dirname, 'index.html')).throws(new Error('!!'));
+        let config = new proxy.QuestionConfig(__dirname, new BuildOpts());
+        expect(() => config.markup).to.throw(Error, proxy.QuestionConfig.fileError('index.html'));
+      });
     });
 
     describe('npmDependencies', () => {

--- a/test/unit/question/question-config-test.js
+++ b/test/unit/question/question-config-test.js
@@ -19,7 +19,10 @@ describe('QuestionConfig', () => {
 
     get m() {
       return proxyquire('../../../src/question/question-config', {
-        'fs-extra': fsExtra
+        'fs-extra': fsExtra,
+        './config-validator': {
+          validate: stub().returns({ valid: true, errors: [] })
+        }
       });
     }
 
@@ -85,12 +88,10 @@ describe('QuestionConfig', () => {
     });
 
     it('throws an error if the dir does not contain a dependencies.json', () => {
-
       fsExtra.readJsonSync.withArgs(join(__dirname, 'dependencies.json')).throws(new Error('dependencies.json'));
       expect(() => new proxy.QuestionConfig(__dirname, new BuildOpts()))
         .to.throw(Error, proxy.QuestionConfig.fileError('dependencies.json'));
     });
-
 
     it('throws an error if markup file can not be found', () => {
       fsExtra.readFileSync.withArgs(join(__dirname, 'index.html')).throws(new Error('!!'));
@@ -114,12 +115,14 @@ describe('QuestionConfig', () => {
       config = {
         pies: [
           {
+            id: '1',
             pie: {
               name: 'my-pie',
               version: '1.0.0'
             }
           },
           {
+            id: '2',
             pie: {
               name: 'my-other-pie',
               version: '1.0.0'

--- a/test/unit/question/question-config-test.js
+++ b/test/unit/question/question-config-test.js
@@ -1,27 +1,38 @@
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
-import sinon from 'sinon';
-import path from 'path';
+import { stub } from 'sinon';
+import { join } from 'path';
+
 
 describe('QuestionConfig', () => {
-  let QuestionConfig, BuildOpts, fsExtra;
-
-  function proxyModule() {
-    return proxyquire('../../../src/question/question-config', {
-      'fs-extra': fsExtra
-    });
-  }
+  let BuildOpts, fsExtra;
 
   beforeEach(() => {
     fsExtra = {
-      readJsonSync: sinon.stub().returns({}),
-      readFileSync: sinon.stub().returns('<html></html>')
+      readJsonSync: stub(),
+      readFileSync: stub()
     };
-
-    let mod = proxyModule();
-    QuestionConfig = mod.QuestionConfig;
-    BuildOpts = mod.BuildOpts;
+    BuildOpts = proxy.BuildOpts;
   });
+
+  class Proxy {
+
+    get m() {
+      return proxyquire('../../../src/question/question-config', {
+        'fs-extra': fsExtra
+      });
+    }
+
+    get BuildOpts() {
+      return this.m.BuildOpts;
+    }
+
+    get QuestionConfig() {
+      return this.m.QuestionConfig;
+    }
+  }
+
+  let proxy = new Proxy();
 
   describe('BuildOpts.build', () => {
 
@@ -43,9 +54,9 @@ describe('QuestionConfig', () => {
 
     it('builds from arg values', () => {
       expect(BuildOpts.build({
-        'questionConfigFile' : 'c.json',
-        'questionDependenciesFile' : 'd.json',
-        'questionMarkupFile' : 'i.html'
+        'questionConfigFile': 'c.json',
+        'questionDependenciesFile': 'd.json',
+        'questionMarkupFile': 'i.html'
       })).to.eql({
         config: 'c.json',
         dependencies: 'd.json',
@@ -56,22 +67,41 @@ describe('QuestionConfig', () => {
 
   describe('constructor', () => {
 
+    beforeEach(() => {
+
+      fsExtra = {
+        readJsonSync: stub()
+          .withArgs(join(__dirname, 'config.json')).returns({})
+          .withArgs(join(__dirname, 'dependencies.json')).returns({}),
+        readFileSync: stub()
+          .withArgs(join(__dirname, 'index.html')).returns('<div>hi</div>')
+      }
+    });
+
+
     it('throws an error if the dir does not contain a config.json', () => {
-      fsExtra.readJsonSync = sinon.stub().throws(new Error('config.json'));
-      expect(() => new QuestionConfig(__dirname, new BuildOpts())).to.throw(Error, /config\.json/);
+      fsExtra.readJsonSync.throws(new Error('config.json'));
+      expect(() => new proxy.QuestionConfig(__dirname, new BuildOpts())).to.throw(Error, proxy.QuestionConfig.fileError('config.json'));
     });
 
     it('throws an error if the dir does not contain a dependencies.json', () => {
-      fsExtra.readJsonSync = sinon.stub();
-      fsExtra.readJsonSync.withArgs(path.join(__dirname, 'config.json')).returns({});
-      fsExtra.readJsonSync.withArgs(path.join(__dirname, 'dependencies.json')).throws(new Error('dependencies.json'));
-      expect(() => new QuestionConfig(__dirname, new BuildOpts())).to.throw(Error, /dependencies\.json/);
+
+      fsExtra.readJsonSync.withArgs(join(__dirname, 'dependencies.json')).throws(new Error('dependencies.json'));
+      expect(() => new proxy.QuestionConfig(__dirname, new BuildOpts()))
+        .to.throw(Error, proxy.QuestionConfig.fileError('dependencies.json'));
+    });
+
+
+    it('throws an error if markup file can not be found', () => {
+      fsExtra.readFileSync.withArgs(join(__dirname, 'index.html')).throws(new Error('!!'));
+      expect(() => new (proxy.QuestionConfig)(__dirname, new BuildOpts()))
+        .to.throw(Error, proxy.QuestionConfig.fileError('index.html'));
     });
 
     it('not throw an error if the dir contains config.json + dependencies.json', () => {
-      expect(() => new QuestionConfig(__dirname, new BuildOpts())).not.to.throw(Error);
+      expect(() => new proxy.QuestionConfig(__dirname, new BuildOpts()))
+        .not.to.throw(Error);
     });
-
   });
 
   describe('methods', () => {
@@ -96,23 +126,23 @@ describe('QuestionConfig', () => {
             }
           }]
       }
-      fsExtra.readJsonSync.withArgs(path.join(__dirname, 'config.json')).returns(config);
-      fsExtra.readJsonSync.withArgs(path.join(__dirname, 'dependencies.json')).returns(dependencies);
+      fsExtra.readJsonSync.withArgs(join(__dirname, 'config.json')).returns(config);
+      fsExtra.readJsonSync.withArgs(join(__dirname, 'dependencies.json')).returns(dependencies);
     });
 
     describe('npmDependencies', () => {
       it('returns an object with any pie with local path as the key:value', () => {
-        let q = new QuestionConfig(__dirname, new BuildOpts());
+        let q = new proxy.QuestionConfig(__dirname, new BuildOpts());
         expect(q.npmDependencies).to.eql({ 'my-pie': '../..' });
       });
     });
 
     describe('get pies', () => {
       it('returns 2 pie', () => {
-        let q = new QuestionConfig(__dirname, new BuildOpts());
+        let q = new proxy.QuestionConfig(__dirname, new BuildOpts());
         expect(q.pies).to.eql([
-          { name: 'my-pie', versions: ['1.0.0'], localPath: '../..', installedPath: path.join(__dirname, 'node_modules/my-pie') },
-          { name: 'my-other-pie', versions: ['1.0.0'], localPath: undefined, installedPath: path.join(__dirname, 'node_modules/my-other-pie') }
+          { name: 'my-pie', versions: ['1.0.0'], localPath: '../..', installedPath: join(__dirname, 'node_modules/my-pie') },
+          { name: 'my-other-pie', versions: ['1.0.0'], localPath: undefined, installedPath: join(__dirname, 'node_modules/my-other-pie') }
         ]);
       });
     });
@@ -120,32 +150,28 @@ describe('QuestionConfig', () => {
     describe('get piePackages', () => {
       beforeEach(() => {
         fsExtra = {
-          readJsonSync: sinon.stub().returns({}),
-          readFileSync: sinon.stub().returns('<html></html>'),
-          existsSync: sinon.stub().returns(true)
+          readJsonSync: stub().returns({}),
+          readFileSync: stub().returns('<html></html>'),
+          existsSync: stub().returns(true)
         };
-
-        QuestionConfig = proxyquire('../../../src/question/question-config', {
-          'fs-extra': fsExtra
-        }).QuestionConfig;
       });
 
       it('returns an empty array for an empty config', () => {
-        let q = new QuestionConfig(__dirname, new BuildOpts());
+        let q = new proxy.QuestionConfig(__dirname, new BuildOpts());
         expect(q.piePackages).to.eql([]);
       });
 
       it('throws an error if node_modules does not exist', () => {
-        fsExtra.existsSync = sinon.stub().withArgs(path.join(__dirname, 'node_modules')).returns(false);
-        let q = new QuestionConfig(__dirname, new BuildOpts());
+        fsExtra.existsSync = stub().withArgs(join(__dirname, 'node_modules')).returns(false);
+        let q = new proxy.QuestionConfig(__dirname, new BuildOpts());
         expect(() => q.piePackages).to.throw(Error);
       });
 
       it('returns the package.json for 1 pie', () => {
 
-        fsExtra.existsSync = sinon.stub().returns(true);
+        fsExtra.existsSync = stub().returns(true);
         fsExtra.readJsonSync.withArgs(
-          path.join(__dirname, 'node_modules', 'my-pie', 'package.json'))
+          join(__dirname, 'node_modules', 'my-pie', 'package.json'))
           .returns({
             name: 'my-pie',
             dependencies: {
@@ -153,7 +179,7 @@ describe('QuestionConfig', () => {
             }
           });
         fsExtra.readJsonSync.withArgs(
-          path.join(__dirname, 'config.json'))
+          join(__dirname, 'config.json'))
           .returns({
             pies: [
               {
@@ -164,7 +190,7 @@ describe('QuestionConfig', () => {
               }
             ]
           });
-        let q = new QuestionConfig(__dirname, new BuildOpts());
+        let q = new proxy.QuestionConfig(__dirname, new BuildOpts());
         expect(q.piePackages).to.eql([{
           name: 'my-pie',
           dependencies: {


### PR DESCRIPTION
This adds some simple validation to `pack-question` and `serve-question`.

* checks that the `config.json` is present
* checks that `dependencies.json` is present
* checks that `index.html` is present
* validates `config.json` with 1 base schema that checks for `pies: [ { pie: { name: version: }}]` and then validates the individual pies with the schema located in `$pie/docs/schema/config.json`.

The command will fail if any of the above checks fail.

## original notes
When we run `pack-question` or `serve-question` we should first check that: 
1. the files are where we expect to find them
2. the config.json has the correct structure
3. the dependencies.json has the correct structure
4. the html file is present (check for instance declarations too?)
