### PR TITLE
Pie-cli should allow same loader with different test regexp and config

### DIFF
--- a/src/code-gen/duplicate-loaders.js
+++ b/src/code-gen/duplicate-loaders.js
@@ -22,11 +22,13 @@ let _getDuplicates = (config) => {
 
     let wrapped = new Loader(loader);
     let name = wrapped.normalizedName;
+    let test = wrapped.test;
+    let uid = `${name}-${test}`;
 
-    if (acc[name]) {
-      acc[name].push(wrapped);
+    if (acc[uid]) {
+      acc[uid].push(wrapped);
     } else {
-      acc[name] = [wrapped];
+      acc[uid] = [wrapped];
     }
     return acc;
   }, {});

--- a/src/code-gen/loaders.js
+++ b/src/code-gen/loaders.js
@@ -6,6 +6,11 @@ export class Loader {
     this._raw = obj;
     this._names = new LoaderNames(obj.loader);
   }
+
+  get test() {
+    return this._raw.test;
+  }
+
   get normalizedName() {
     return this._names.normalized;
   }

--- a/test/unit/code-gen/duplicate-loaders-test.js
+++ b/test/unit/code-gen/duplicate-loaders-test.js
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
 import { buildLogger } from '../../../src/log-factory';
+import _ from 'lodash';
+
 const logger = buildLogger();
 
 describe('duplicate-loaders', () => {
@@ -10,8 +12,8 @@ describe('duplicate-loaders', () => {
     config = {
       module: {
         loaders: [
-          { loader: 'a!b' },
-          { loader: 'a!b' }
+          { loader: 'a!b', test: /\.js$/ },
+          { loader: 'a!b', test: /\.js$/ }
         ]
       }
     }
@@ -31,6 +33,17 @@ describe('duplicate-loaders', () => {
 
     it('returns duplicates w/ present=false for an empty config.module.loaders', () => {
       expect(DuplicateLoaders.fromConfig({ module: {} }).present).to.eql(false);
+    });
+
+    it('returns duplicates w/ present=false for a config with same loaders but different tests', () => {
+
+      let tweaked = _.cloneDeep(config);
+
+      tweaked.module.loaders[0].test = /js$/;
+
+      let duplicates = DuplicateLoaders.fromConfig(tweaked);
+      logger.debug('duplicates: ', duplicates);
+      expect(duplicates.present).to.eql(false);
     });
 
     it('returns duplicates w/ present=true for a config', () => {


### PR DESCRIPTION
```javascript 
{
  test: /\.(eot|svg|ttf|woff|woff2)([#?].*)?$/,
  loader: 'file?name=public/fonts/[name].[ext]'
},
{
  test: /\/images\/feedback\/.*\.png/,
  loader: 'file?name=public/images/feedback/[name].[ext]'
}
```