### PR TITLE
re-add --keepBuildAssets that defaults to false for pack-question

### DIFF
--- a/src/cli/clean-question.js
+++ b/src/cli/clean-question.js
@@ -1,6 +1,9 @@
 import Question from '../question';
 import { resolve } from 'path';
 import { buildLogger } from '../log-factory';
+import { join } from 'path';
+import { removeSync } from 'fs-extra';
+import { PackQuestionOpts } from './pack-question';
 
 const marked = require('marked');
 const TerminalRenderer = require('marked-terminal');
@@ -42,7 +45,9 @@ export function run(args) {
   //Note: we don't need framework support for a clean
   let noExternalSupport = [];
   let questionOpts = Question.buildOpts(args);
+  let packOpts = PackQuestionOpts.build(args);
   let question = new Question(dir, questionOpts, noExternalSupport, emptyApp);
   return question.clean(dir, args)
+    .then(() => removeSync(join(dir, packOpts.exampleFile)))
     .then(() => "clean complete")
 }

--- a/src/cli/pack-question.js
+++ b/src/cli/pack-question.js
@@ -10,11 +10,12 @@ import tmpSupport from './tmp-support';
 const logger = buildLogger();
 
 export class PackQuestionOpts {
-  constructor(dir, clean, buildExample, exampleFile) {
+  constructor(dir, clean, buildExample, exampleFile, keepBuildAssets) {
     this.dir = dir;
     this.clean = clean;
     this.buildExample = buildExample;
     this.exampleFile = exampleFile;
+    this.keepBuildAssets = keepBuildAssets;
   }
 
   static build(args) {
@@ -27,7 +28,8 @@ export class PackQuestionOpts {
       args.dir || process.cwd(),
       args.clean === 'true' || args.clean === true,
       args.buildExample !== 'false' && args.buildExample !== false,
-      args.exampleFile || 'example.html');
+      args.exampleFile || 'example.html', 
+      args.keepBuildAssets || false);
   }
 }
 
@@ -43,6 +45,17 @@ class PackQuestionCommand extends CliCommand {
     let questionOpts = Question.buildOpts(args);
     let question = new Question(dir, questionOpts, tmpSupport, exampleApp);
 
+    logger.silly('[run] packOpts? ', packOpts);
+
+    let maybeDeleteBuildAssets = packOpts.keepBuildAssets ? Promise.resolve() : () => {
+      return question.clean()
+        .then(() => {
+          if(!packOpts.buildExample){
+            removeSync(join(dir, packOpts.exampleFile));
+          }
+        });
+    }
+
     return question.pack(packOpts.clean)
       .then((result) => {
         logger.debug('pack result: ', result);
@@ -57,6 +70,7 @@ class PackQuestionCommand extends CliCommand {
             controllers: result.controllers.library
           }
 
+          logger.silly('question: ', question)
           let markup = exampleApp.staticMarkup(paths, ids, question.config.markup, question.config.config);
 
           logger.silly('markup: ', markup);
@@ -69,7 +83,8 @@ class PackQuestionCommand extends CliCommand {
 
           return softWrite(examplePath, markup);
         }
-      });
+      })
+      .then(maybeDeleteBuildAssets);
   }
 }
 

--- a/src/cli/pack-question.md.ejs
+++ b/src/cli/pack-question.md.ejs
@@ -19,7 +19,7 @@ It generates 2 javascript files:
   `--questionConfigFile` - the name of the pie data file - default `config.json`
   `--questionDependenciesFile` - the name of the pie data file - default `dependencies.json`
   `--questionMarkupFile` - the name of layout file - default `index.html`
-  ~~`--keepBuildAssets` - keep supporting build assets (like node_modules etc) after packing has completed - default:  `true`~~
+  `--keepBuildAssets` - keep supporting build assets (like node_modules etc) after packing has completed - default: `false`
   `--buildExample` - build an example? - default: `true`  
   `--exampleFile` - if building an example - the name of the generated example html file. default: `example.html`  
   

--- a/src/question/index.js
+++ b/src/question/index.js
@@ -1,7 +1,6 @@
 import { ClientBuildable, BuildOpts as ClientBuildOpts } from './client';
 import { ControllersBuildable, BuildOpts as ControllersBuildOpts } from './controllers';
 import { QuestionConfig, BuildOpts as QuestionConfigBuildOpts } from './question-config';
-import { join } from 'path';
 import { removeSync } from 'fs-extra';
 import { buildLogger } from '../log-factory';
 
@@ -31,9 +30,7 @@ export default class Question {
   clean() {
     return this.client.clean()
       .then(() => this.controllers.clean())
-      .then(() => removeSync(this.controllers.controllersDir))
-      //TODO - does this belong here? We don't build the example in Question'
-      .then(() => removeSync(join(this.dir, 'example.html')));
+      .then(() => removeSync(this.controllers.controllersDir));
   }
 
   pack(clean = false) {

--- a/test/init.js
+++ b/test/init.js
@@ -6,3 +6,9 @@ const logFactory = require('../src/log-factory');
 logFactory.init(process.env.LOG_LEVEL || 'info');
 
 global.testLogger = logFactory.getLogger('TEST');
+
+global.logSpy = (s) => {
+  for(var i = 0; i < s.callCount; i++){
+    global.testLogger.info('call: ', i, ': ', s.getCall(i).args);
+  }
+}

--- a/test/unit/cli/clean-question-test.js
+++ b/test/unit/cli/clean-question-test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { assert, stub, spy } from 'sinon';
 
-describe('pack-question', () => {
+describe('clean-question', () => {
 
   let cmd, questionConstructor, questionInstance, buildOpts, fsExtra, path;
 
@@ -19,10 +19,6 @@ describe('pack-question', () => {
     }
 
     questionInstance = {
-      config: {
-        markup: '<div></div>',
-        config: {}
-      },
       pack: stub().returns(Promise.resolve({ 
         controllers: { 
           filename: 'controller.js', 
@@ -40,9 +36,10 @@ describe('pack-question', () => {
       controllers: {},
       config: {}
     }
+    
     questionConstructor.buildOpts = stub().returns(buildOpts);
 
-    cmd = proxyquire('../../../src/cli/pack-question', {
+    cmd = proxyquire('../../../src/cli/clean-question', {
       '../question': {
         default: questionConstructor
       },
@@ -53,14 +50,13 @@ describe('pack-question', () => {
 
   describe('match', () => {
 
-    it('returns true for pack-question', () => {
-      expect(cmd.match({ _: ['pack-question'] })).to.eql(true);
+    it('returns true for clean-question', () => {
+      expect(cmd.match({ _: ['clean-question'] })).to.eql(true);
     });
   });
 
   describe('run', () => {
 
-    describe('with keepBuildAssets=false', () => {
       beforeEach((done) => {
       cmd.run({dir: 'dir', buildExample: false})
         .then(() => {
@@ -69,17 +65,12 @@ describe('pack-question', () => {
         .catch(done);
       });
 
-      it('calls pack', () => {
-        assert.calledWith(questionInstance.pack, false);
-      });
-      
-      it('calls clean', () => {
+      it('calls question.clean', () => {
         assert.called(questionInstance.clean);
       });
-      
-      it('calls removeSync if buildExample=false', () => {
+
+      it('calls removeSync on example.html', () => {
         assert.calledWith(fsExtra.removeSync, 'dir/example.html');
       });
     });
-  });
 });

--- a/test/unit/question/index-test.js
+++ b/test/unit/question/index-test.js
@@ -133,10 +133,6 @@ describe('Question', () => {
       assert.calledWith(fs.removeSync, 'controllersDir');
     });
 
-    it('calls removeSync on example.html', () => {
-      assert.calledWith(fs.removeSync, 'dir/example.html');
-    });
-
   });
 
   describe('pack', () => {


### PR DESCRIPTION
`--keepBuildAssets` should be an option when running `pack-question` - if it's not present then build assets are removed once compilation/packing has completed.