### PR TITLE
pie --version shows an empty 'git-sha: ' on when running the npm installed package

### DIFF
--- a/src/cli/version.js
+++ b/src/cli/version.js
@@ -1,6 +1,10 @@
 import { existsSync, readJsonSync } from 'fs-extra';
 import { execSync } from 'child_process';
 import { join } from 'path';
+import isEmpty from 'lodash/isEmpty';
+import {buildLogger} from '../log-factory';
+
+const logger = buildLogger();
 
 export function match(args) {
   let out = (args.v || args.version);
@@ -9,7 +13,7 @@ export function match(args) {
 
 export let summary = '--version | -v - print the version';
 
-export function run() {
+export function run(log = console.log) {
   let pkg = readJsonSync(join(__dirname, '..', '..', 'package.json'));
   let projectRoot = join(__dirname, '../..');
   let gitDir = join(projectRoot, '.git');
@@ -18,6 +22,10 @@ export function run() {
     gitSha = execSync(`git --git-dir=${gitDir} --work-tree=${projectRoot} rev-parse --short HEAD`, { encoding: 'utf8' });
     gitSha = gitSha.trim();
   }
-  console.log(`version: ${pkg.version}, git-sha: ${gitSha}`);
+  let message = `version: ${pkg.version}`;
+  message += isEmpty(gitSha) ? '' : `, git-sha: ${gitSha}`;
+  console.log('message: ', message);
+  logger.info('message: ', message);
+  log(message); 
   process.exit(0);
 };

--- a/test/unit/cli/version-test.js
+++ b/test/unit/cli/version-test.js
@@ -1,0 +1,46 @@
+import proxyquire from 'proxyquire';
+import {assert, stub} from 'sinon';
+
+describe('version', () => {
+  
+  let cmd, log, gitExists;
+
+  let getCmd = () => {
+    return proxyquire('../../../src/cli/version', {
+      'fs-extra' : {
+        readJsonSync: stub().returns({version: '1.0.0'}),
+        existsSync: stub().returns(gitExists)
+      },
+      'child_process' : {
+        execSync: stub().returns('HASH')
+      }
+    }); 
+  }
+
+  beforeEach(() => {
+    log = stub();
+    gitExists = false;
+    process.exit = stub();
+    cmd = getCmd();
+  });
+
+
+  it('does not add git-sha if .git dir doesnt exist', () => {
+    cmd.run(log);
+    assert.calledWith(log, 'version: 1.0.0');
+  });
+
+  describe('if .git dir exists', () => {
+
+    beforeEach(() => {
+      gitExists = true;
+      cmd = getCmd();
+    });
+
+    it('does add git-sha if .git dir exists', () => {
+      cmd.run(log);
+      assert.calledWith(log, 'version: 1.0.0, git-sha: HASH');
+    });
+
+  }); 
+});


### PR DESCRIPTION
```shell 
npm install -g pie
pie --version 
#Actual: version: 1.5.0 git-sha: 
#Expected: version: 1.5.0
```