### PR TITLE
if --clean=false, pack should still install any uninstalled packages

### DIFF
--- a/src/npm/npm-dir.js
+++ b/src/npm/npm-dir.js
@@ -127,17 +127,8 @@ export default class NpmDir {
 
   install(dependencies) {
     logger.info('[install] ...');
-    let pkgExists = this._exists('package.json')
-    let nodeModulesExists = this._exists('node_modules');
-
-    logger.silly('[install] pkgExists: ', pkgExists)
-    if (pkgExists && nodeModulesExists) {
-      logger.info('[install] skipping install cmd');
-      return Promise.resolve({ skipped: true });
-    } else {
-      return this._writePackageJson(dependencies)
-        .then(() => this._install());
-    }
+    return this._writePackageJson(dependencies)
+      .then(() => this._install());
   };
 
   _install(args) {

--- a/test/unit/npm/npm-dir-test.js
+++ b/test/unit/npm/npm-dir-test.js
@@ -51,26 +51,7 @@ describe('npm-dir', () => {
     let dir;
     beforeEach(() => {
       dir = new NpmDir(__dirname);
-      dir._exists = sinon.stub()
-        .withArgs('package.json').returns(false)
-        .withArgs('node_modules').returns(false);
-    });
-
-    it('skips install if package.json and node_modules exists', (done) => {
-
-      withCloseHandler(() => {
-        dir._exists
-          .withArgs('package.json').returns(true)
-          .withArgs('node_modules').returns(true);
-
-        dir.install({})
-          .then((result) => {
-            expect(result.skipped).to.eql(true);
-            done();
-          })
-          .catch(done);
-
-      });
+      dir._exists = sinon.stub();
     });
 
     it('writes package.json when installing', (done) => {


### PR DESCRIPTION
with `--clean=false` we skip running an npm install if the `node_modules` dir is present. Instead we should inspect what's installed and compare it to what needs to be installed, if there are any outstanding dependencies - install just those.