### PR TITLE
add command to generate unique id hash from unpackaged question 

### DIFF
--- a/src/cli/help.js
+++ b/src/cli/help.js
@@ -26,7 +26,7 @@ export default class Help {
       let usage = _(this.handlers).map((h) => `\t${h.summary}`).join('\n');
       console.log(usage);
       console.log('--');
-      console.log('you can also run: \n\tpie-cli help $cmd\nfor more detail.')
+      console.log(`you can also run: \n\t${this.rootCmd} help $command-name\nfor more detail.`);
     }
     return Promise.resolve('--');
   }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -18,7 +18,7 @@ export default function (opts) {
 
   opts = normalizeOpts(opts);
 
-  let help = new Help('pie-cli', commands);
+  let help = new Help('pie', commands);
 
   let cmd = _.find([help].concat(commands), (cmd) => {
     return cmd.match(opts);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -4,12 +4,14 @@ import * as version from './version';
 import * as packQuestion from './pack-question';
 import * as cleanQuestion from './clean-question';
 import * as serveQuestion from './serve-question';
+import * as manifest from './manifest';
 import {normalizeOpts} from './helper';
 let commands = [
   version,
   packQuestion,
   cleanQuestion,
-  serveQuestion
+  serveQuestion,
+  manifest
 ];
 
 export default function (opts) {

--- a/src/cli/manifest.js
+++ b/src/cli/manifest.js
@@ -1,7 +1,20 @@
 import { buildLogger } from '../log-factory';
 import CliCommand from './cli-command';
+import { writeJsonSync } from 'fs-extra';
+import { make as makeManifest } from '../question/manifest';
 
 const logger = buildLogger();
+
+class ManifestOpts {
+  constructor(dir = process.cwd(), outfile = null) {
+    this.dir = dir;
+    this.outfile = outfile;
+  }
+
+  static buildOpts(args) {
+    return new ManifestOpts(args.dir, args.outfile);
+  }
+}
 
 class ManifestCommand extends CliCommand {
   constructor() {
@@ -9,8 +22,15 @@ class ManifestCommand extends CliCommand {
   }
 
   run(args) {
-    logger.info('[run] args: ', args);
-    return Promise.reject(new Error('todo...'));
+    let opts = ManifestOpts.buildOpts(args);
+    logger.info('[run] opts: ', opts);
+
+    let manifest = makeManifest(opts.dir);
+
+    if (opts.outfile) {
+      writeJsonSync(opts.outfile, manifest);
+    }
+    return Promise.resolve(JSON.stringify(manifest));
   }
 }
 

--- a/src/cli/manifest.js
+++ b/src/cli/manifest.js
@@ -1,0 +1,22 @@
+import { buildLogger } from '../log-factory';
+import CliCommand from './cli-command';
+
+const logger = buildLogger();
+
+class ManifestCommand extends CliCommand {
+  constructor() {
+    super('manifest', 'get a hash of the pie names and versions');
+  }
+
+  run(args) {
+
+    logger.info('[run] args: ', args);
+    return Promise.reject(new Error('todo...'));
+  }
+}
+
+let cmd = new ManifestCommand();
+exports.match = cmd.match.bind(cmd);
+exports.usage = cmd.usage;
+exports.summary = cmd.summary;
+exports.run = cmd.run.bind(cmd);

--- a/src/cli/manifest.js
+++ b/src/cli/manifest.js
@@ -9,7 +9,6 @@ class ManifestCommand extends CliCommand {
   }
 
   run(args) {
-
     logger.info('[run] args: ', args);
     return Promise.reject(new Error('todo...'));
   }

--- a/src/cli/manifest.md
+++ b/src/cli/manifest.md
@@ -1,3 +1,14 @@
 # manifest
 
-get a unique hash built from the pie names + versions defined in this question.
+Get a unique hash built from the pie names + versions defined in this question. The last line from the command is a json string.
+
+## Options
+
+`--outfile` - file path to write out manifest to. default: not set (no file is written).
+`--dir` - the directory of the question default: the current working directory. 
+
+## Examples 
+
+`pie manifest --outfile my-manifest.json`
+
+`pie manifest --dir some/dir --outfile my-manifest.json`

--- a/src/cli/manifest.md
+++ b/src/cli/manifest.md
@@ -1,0 +1,3 @@
+# manifest
+
+get a unique hash built from the pie names + versions defined in this question.

--- a/src/cli/pack-question.js
+++ b/src/cli/pack-question.js
@@ -6,7 +6,7 @@ import ExampleApp from '../example-app';
 import { softWrite } from '../file-helper';
 import { removeSync } from 'fs-extra';
 import tmpSupport from './tmp-support';
-
+import { run as runManifest } from './manifest';
 const logger = buildLogger();
 
 export class PackQuestionOpts {
@@ -28,7 +28,7 @@ export class PackQuestionOpts {
       args.dir || process.cwd(),
       args.clean === 'true' || args.clean === true,
       args.buildExample !== 'false' && args.buildExample !== false,
-      args.exampleFile || 'example.html', 
+      args.exampleFile || 'example.html',
       args.keepBuildAssets || false);
   }
 }
@@ -50,7 +50,7 @@ class PackQuestionCommand extends CliCommand {
     let maybeDeleteBuildAssets = packOpts.keepBuildAssets ? Promise.resolve() : () => {
       return question.clean()
         .then(() => {
-          if(!packOpts.buildExample){
+          if (!packOpts.buildExample) {
             removeSync(join(dir, packOpts.exampleFile));
           }
         });
@@ -84,7 +84,8 @@ class PackQuestionCommand extends CliCommand {
           return softWrite(examplePath, markup);
         }
       })
-      .then(maybeDeleteBuildAssets);
+      .then(maybeDeleteBuildAssets)
+      .then(() => runManifest({ outfile: args.manifestOutfile }));
   }
 }
 

--- a/src/cli/pack-question.md.ejs
+++ b/src/cli/pack-question.md.ejs
@@ -22,6 +22,7 @@ It generates 2 javascript files:
   `--keepBuildAssets` - keep supporting build assets (like node_modules etc) after packing has completed - default: `false`
   `--buildExample` - build an example? - default: `true`  
   `--exampleFile` - if building an example - the name of the generated example html file. default: `example.html`  
+  `--manifestOutfile` - where to write out the manifest.json default: `null`
   
 ### Examples
 ```shell

--- a/src/npm/dependency-helper.js
+++ b/src/npm/dependency-helper.js
@@ -1,4 +1,3 @@
-//@flow
 import semver from 'semver';
 import fs from 'fs-extra';
 import path from 'path';
@@ -22,15 +21,30 @@ export let pathIsDir = (root, v) => {
   }
 };
 
+export let dependenciesToHashAndSrc = (dependencies) => {
+  if (!dependencies || !_.isObject(dependencies) || _.isEmpty(dependencies)) {
+    throw new Error('dependencies must be an non empty object');
+  }
+
+  let src = toSrc(dependencies);
+  return { hash: hash(src), src: src };
+}
+
 export let dependenciesToHash = (dependencies) => {
   if (!dependencies || !_.isObject(dependencies) || _.isEmpty(dependencies)) {
     throw new Error('dependencies must be an non empty object');
   }
 
-  let raw = _.reduce(dependencies, (acc, value, key) => {
-    acc += `${key}:${value}`;
-    return acc;
-  }, '');
-
-  return crypto.createHash('md5').update(raw).digest('hex');
+  let src = toSrc(dependencies);
+  return hash(src);
 };
+
+let toSrc = (dependencies) => {
+  let keyed = _.map(dependencies, (value, key) => `${key}:${value}`);
+  keyed.sort();
+  return keyed.join(',');
+};
+
+let hash = (s) => {
+  return crypto.createHash('md5').update(s).digest('hex');
+}

--- a/src/question/manifest.js
+++ b/src/question/manifest.js
@@ -1,0 +1,9 @@
+import { QuestionConfig } from './question-config';
+import { dependenciesToHashAndSrc } from '../npm/dependency-helper';
+
+export function make(dir) {
+  let config = new QuestionConfig(dir);
+  let dependencies = config.npmDependencies;
+  let {hash, src} = dependenciesToHashAndSrc(config.npmDependencies);
+  return { hash, src, dependencies };
+}

--- a/src/question/question-config.js
+++ b/src/question/question-config.js
@@ -120,9 +120,6 @@ export class QuestionConfig {
         acc[p.name] = p.localPath;
       } else {
 
-        logger.info('p: ', p);
-        logger.info('p.versions: ', p.versions);
-
         /**
          * TODO: We don't have a strategy in place for different versions (or version ranges) of the same pie.
          * For now throw an error if we find multiple versions.

--- a/src/question/question-config.js
+++ b/src/question/question-config.js
@@ -118,6 +118,20 @@ export class QuestionConfig {
       logger.silly('[npmDependencies] p: ', p);
       if (p.localPath) {
         acc[p.name] = p.localPath;
+      } else {
+
+        logger.info('p: ', p);
+        logger.info('p.versions: ', p.versions);
+
+        /**
+         * TODO: We don't have a strategy in place for different versions (or version ranges) of the same pie.
+         * For now throw an error if we find multiple versions.
+         */
+        if (p.versions.length > 1) {
+          throw new Error(`multiple versions found for ${p.name}`);
+        }
+
+        acc[p.name] = _.first(p.versions)
       }
       return acc;
     }, {});
@@ -128,7 +142,7 @@ export class QuestionConfig {
     let toUniqueNames = (acc, p) => {
       let existing = _.find(acc, { name: p.name });
       if (existing) {
-        existing.versions = _(existing.versions).concat(p.version).uniq();
+        existing.versions = _(existing.versions).concat(p.version).uniq().value();
       }
       else {
         acc.push({

--- a/test/init.js
+++ b/test/init.js
@@ -8,7 +8,7 @@ logFactory.init(process.env.LOG_LEVEL || 'info');
 global.testLogger = logFactory.getLogger('TEST');
 
 global.logSpy = (s) => {
-  for(var i = 0; i < s.callCount; i++){
-    global.testLogger.info('call: ', i, ': ', s.getCall(i).args);
+  for (var i = 0; i < s.callCount; i++) {
+    global.testLogger.info('call: ', i, ': ', JSON.stringify(s.getCall(i).args));
   }
 }

--- a/test/integration/cli/manifest-test.js
+++ b/test/integration/cli/manifest-test.js
@@ -1,0 +1,27 @@
+import { setUpTmpQuestionAndComponents } from '../integration-test-helper';
+import { join } from 'path';
+import { removeSync } from 'fs-extra';
+import { run } from '../../../src/cli/manifest';
+import { expect } from 'chai';
+import { readJsonSync } from 'fs-extra';
+
+describe('manifest', () => {
+  let tmpPath, questionPath, manifestPath;
+
+  beforeEach((done) => {
+    tmpPath = setUpTmpQuestionAndComponents('manifest-test');
+    questionPath = join(tmpPath, 'example-questions/one');
+    removeSync(join(questionPath, 'dependencies.json'));
+    manifestPath = join(questionPath, 'manifest.json');
+    run({ dir: questionPath, outfile: manifestPath })
+      .then(() => done())
+      .catch(done);
+  });
+
+  it('writes out a manifest', () => {
+    expect(readJsonSync(manifestPath).dependencies).to.eql({
+      'hello-world': '~1.0.0'
+    });
+  });
+
+});

--- a/test/integration/example-components/hello-world/package.json
+++ b/test/integration/example-components/hello-world/package.json
@@ -1,20 +1,18 @@
 {
-  "name" : "hello-world",
-  "version" : "1.0.0",
+  "name": "hello-world",
+  "version": "1.0.0",
   "license": "MIT",
   "description": "Just a test pkg",
-  "repository": {
-    
-  },
-  "main" : "lib/index.js",
+  "repository": {},
+  "main": "lib/index.js",
   "dependencies": {
-    "react" : "~15.3.2",
-    "react-dom" : "~15.3.2"
+    "react": "~15.4.0",
+    "react-dom": "~15.4.0"
   },
-  "pie" : {
-    "version" : "~1.0.0",
-    "build" : [ 
+  "pie": {
+    "version": "~1.0.0",
+    "build": [
       "less"
-    ] 
+    ]
   }
 }

--- a/test/unit/cli/manifest-test.js
+++ b/test/unit/cli/manifest-test.js
@@ -1,0 +1,72 @@
+import proxyquire from 'proxyquire';
+import { assert, stub } from 'sinon';
+import { expect } from 'chai';
+
+describe('manifest', () => {
+  let cmd, make, manifestResult, cmdResult, fsExtra;
+
+  beforeEach(() => {
+    process.cwd = stub().returns('dir');
+
+    fsExtra = {
+      writeJsonSync: stub()
+    }
+
+    manifestResult = { hash: 'XXX', src: 'src', dependencies: {} };
+
+    make = stub().returns(manifestResult);
+
+    cmd = proxyquire('../../../src/cli/manifest', {
+      'fs-extra': fsExtra,
+      '../question/manifest': {
+        make: make
+      }
+    });
+  });
+
+  let run = (args) => {
+    args = args || {};
+    return (done) => {
+      cmd.run(args)
+        .then((m) => {
+          cmdResult = m;
+          done()
+        })
+        .catch(done);
+    }
+  }
+
+  describe('run', () => {
+    describe('with no opts', () => {
+
+      beforeEach(run());
+
+      it('calls makeManifest with default dir', () => {
+        assert.calledWith(make, 'dir');
+      });
+
+      it('gets the result', () => expect(cmdResult).to.eql(JSON.stringify(manifestResult)));
+
+    });
+
+    describe('with outfile', () => {
+      beforeEach(run({ outfile: 'manifest.json' }));
+
+      it('calls writeJsonSync', () => {
+        assert.calledWith(fsExtra.writeJsonSync, 'manifest.json', manifestResult);
+      });
+
+      it('gets the result', () => expect(cmdResult).to.eql(JSON.stringify(manifestResult)));
+    });
+
+    describe('with dir', () => {
+
+      beforeEach(run({ dir: 'other-dir' }));
+
+      it('calls makeManifest with passed in dir opt', () => {
+        assert.calledWith(make, 'other-dir');
+      });
+    });
+
+  });
+});

--- a/test/unit/cli/pack-question-test.js
+++ b/test/unit/cli/pack-question-test.js
@@ -4,7 +4,14 @@ import { assert, stub, spy } from 'sinon';
 
 describe('pack-question', () => {
 
-  let cmd, questionConstructor, questionInstance, buildOpts, fsExtra, path;
+  let cmd,
+    questionConstructor,
+    questionInstance,
+    buildOpts,
+    fsExtra,
+    path,
+    manifest,
+    exampleApp;
 
   beforeEach(() => {
 
@@ -13,7 +20,7 @@ describe('pack-question', () => {
     }
 
     path = {
-      resolve: spy(function(i){
+      resolve: spy(function (i) {
         return i;
       })
     }
@@ -23,9 +30,9 @@ describe('pack-question', () => {
         markup: '<div></div>',
         config: {}
       },
-      pack: stub().returns(Promise.resolve({ 
-        controllers: { 
-          filename: 'controller.js', 
+      pack: stub().returns(Promise.resolve({
+        controllers: {
+          filename: 'controller.js',
           library: 'id'
         },
         client: 'pie.js'
@@ -40,14 +47,30 @@ describe('pack-question', () => {
       controllers: {},
       config: {}
     }
+
     questionConstructor.buildOpts = stub().returns(buildOpts);
+
+    manifest = {
+      run: stub().returns(Promise.resolve())
+    }
+
+    exampleApp = {
+      staticMarkup: stub().returns('<div>hi</div>')
+    }
 
     cmd = proxyquire('../../../src/cli/pack-question', {
       '../question': {
         default: questionConstructor
       },
-      'fs-extra' : fsExtra,
-      'path': path
+      '../file-helper': {
+        softWrite: stub()
+      },
+      'fs-extra': fsExtra,
+      'path': path,
+      './manifest': manifest,
+      '../example-app': {
+        default: stub().returns(exampleApp)
+      }
     });
   });
 
@@ -60,23 +83,69 @@ describe('pack-question', () => {
 
   describe('run', () => {
 
-    describe('with keepBuildAssets=false', () => {
-      beforeEach((done) => {
-      cmd.run({dir: 'dir', buildExample: false})
-        .then(() => {
-         done();
-        })
-        .catch(done);
-      });
+    let run = (opts) => {
+      return function (done) {
+        global.testLogger.info('questionInstance: ', questionInstance)
+        global.testLogger.info('cmd: ', cmd);
+        cmd.run(opts)
+          .then(() => {
+            global.testLogger.info('run is done.');
+            done();
+          })
+          .catch(e => {
+            global.testLogger.error(e.stack);
+            done(new Error('!'))
+          });
+      }
+    }
 
+    let assertBasics = () => {
       it('calls pack', () => {
-        assert.calledWith(questionInstance.pack, false);
+        try {
+          assert.calledWith(questionInstance.pack, false);
+        } catch (e) {
+          console.log(e);
+          console.log(e.stack);
+        }
       });
-      
+    }
+
+    describe('with manifestOutfile', () => {
+      beforeEach(run({ manifestOutfile: 'manifest.json' }));
+
+      assertBasics();
       it('calls clean', () => {
         assert.called(questionInstance.clean);
       });
-      
+
+      it('calls manifestCmd.run', () => {
+        assert.calledWith(manifest.run, { outfile: 'manifest.json' });
+      });
+    });
+
+    describe('with buildExample=true', () => {
+      beforeEach(run({ buildExample: true }));
+
+      assertBasics();
+
+      it('calls exampleApp.staticMarkup', () => {
+
+        assert.calledWith(exampleApp.staticMarkup, {
+          client: 'pie.js',
+          controllers: 'controller.js'
+        },
+          { controllers: 'id', },
+          questionInstance.config.markup,
+          questionInstance.config.config
+        );
+      });
+    });
+
+    describe('with keepBuildAssets=false', () => {
+      beforeEach(run({ dir: 'dir', buildExample: false }));
+
+      assertBasics();
+
       it('calls removeSync if buildExample=false', () => {
         assert.calledWith(fsExtra.removeSync, 'dir/example.html');
       });

--- a/test/unit/cli/pack-question-test.js
+++ b/test/unit/cli/pack-question-test.js
@@ -85,16 +85,12 @@ describe('pack-question', () => {
 
     let run = (opts) => {
       return function (done) {
-        global.testLogger.info('questionInstance: ', questionInstance)
-        global.testLogger.info('cmd: ', cmd);
         cmd.run(opts)
           .then(() => {
-            global.testLogger.info('run is done.');
             done();
           })
           .catch(e => {
-            global.testLogger.error(e.stack);
-            done(new Error('!'))
+            done(e);
           });
       }
     }

--- a/test/unit/npm/dependency-helper-test.js
+++ b/test/unit/npm/dependency-helper-test.js
@@ -1,16 +1,16 @@
-import {expect} from 'chai';
-import * as path from 'path';
+import { expect } from 'chai';
 import sinon from 'sinon';
 import proxyquire from 'proxyquire';
+import crypto from 'crypto';
 
 describe('dependency-helper', () => {
 
-  let helper; 
+  let helper;
 
   before(() => {
     helper = require('../../../src/npm/dependency-helper');
-  }); 
-  
+  });
+
   describe('isGitUrl', () => {
     it('returns true for git@XXXX', () => {
       expect(helper.isGitUrl('git@github.com:X/y.git')).to.eql(true);
@@ -18,7 +18,7 @@ describe('dependency-helper', () => {
   });
 
   describe('isSemver', () => {
-    
+
     let assert = (key, valid) => {
       it(`returns ${valid} for ${key}`, () => {
         expect(helper.isSemver(key)).to.eql(valid);
@@ -30,13 +30,27 @@ describe('dependency-helper', () => {
     assert('apple', false);
   });
 
+
+  describe('dependenciesToHash', () => {
+
+    it('builds the hash', () => {
+      let hash = helper.dependenciesToHash({ a: '1.0.0' });
+      expect(hash).to.eql(crypto.createHash('md5').update('a:1.0.0').digest('hex'));
+    });
+
+    it('sorts the dependencies before hashing', () => {
+      let hash = helper.dependenciesToHash({ z: '1.0.0', y: '2.0.0', a: '1.0.0' });
+      expect(hash).to.eql(crypto.createHash('md5').update('a:1.0.0,y:2.0.0,z:1.0.0').digest('hex'));
+    });
+  });
+
   describe('pathIsDir', () => {
-    let stat; 
+    let stat;
 
     before(() => {
 
       stat = {
-        isDirectory: sinon.stub().returns(true) 
+        isDirectory: sinon.stub().returns(true)
       };
 
       helper = proxyquire('../../../src/npm/dependency-helper', {
@@ -47,12 +61,12 @@ describe('dependency-helper', () => {
           resolve: sinon.stub().returns('resolved')
         }
       });
-    }); 
+    });
 
     it('returns true if path is dir', () => {
       expect(helper.pathIsDir('root', 'dir')).to.eql(true);
     });
-    
+
     it('returns false if path is dir', () => {
       stat.isDirectory = sinon.stub().returns(false);
       expect(helper.pathIsDir('root', 'dir')).to.eql(false);

--- a/test/unit/question/manifest-test.js
+++ b/test/unit/question/manifest-test.js
@@ -1,0 +1,44 @@
+import proxyquire from 'proxyquire';
+import { assert, stub } from 'sinon';
+import { expect } from 'chai';
+
+describe('manifest', () => {
+  let make, questionConfig, questionInstance, dependencyHelper, makeResult;
+
+  beforeEach(() => {
+
+    questionInstance = {
+      npmDependencies: {
+        a: '1.0.0'
+      }
+    }
+
+    questionConfig = {
+      QuestionConfig: stub().returns(questionInstance)
+    }
+
+    dependencyHelper = {
+      dependenciesToHashAndSrc: stub().returns({ hash: 'hash', src: 'src' })
+    }
+
+    make = proxyquire('../../../src/question/manifest', {
+      './question-config': questionConfig,
+      '../npm/dependency-helper': dependencyHelper
+    }).make;
+  });
+
+  describe('make', () => {
+
+    beforeEach(() => {
+      makeResult = make('dir');
+    });
+
+    it('calls dependenciesToHashAndSrc', () => {
+      assert.calledWith(dependencyHelper.dependenciesToHashAndSrc, questionInstance.npmDependencies);
+    });
+
+    it('returns the result', () => {
+      expect(makeResult).to.eql({ hash: 'hash', src: 'src', dependencies: { a: '1.0.0' } });
+    });
+  });
+});

--- a/test/unit/question/question-config-test.js
+++ b/test/unit/question/question-config-test.js
@@ -5,8 +5,6 @@ import { join } from 'path';
 import { buildLogger } from '../../../src/log-factory';
 const logger = buildLogger();
 
-
-
 describe('QuestionConfig', () => {
   let BuildOpts, fsExtra;
 
@@ -153,7 +151,17 @@ describe('QuestionConfig', () => {
     describe('npmDependencies', () => {
       it('returns an object with any pie with local path as the key:value', () => {
         let q = new proxy.QuestionConfig(__dirname, new BuildOpts());
-        expect(q.npmDependencies).to.eql({ 'my-pie': '../..' });
+        expect(q.npmDependencies).to.eql({ 'my-pie': '../..', 'my-other-pie': '1.0.0' });
+      });
+
+      it('throws an error if there are multiple versions for a given pie', () => {
+        config.pies.push({ pie: { name: 'my-other-pie', version: '1.0.1' } });
+        fsExtra.readJsonSync.withArgs(join(__dirname, 'config.json')).returns(config);
+        let q = new proxy.QuestionConfig(__dirname, new BuildOpts());
+
+        expect(() => {
+          q.npmDependencies
+        }).to.throw('multiple versions found for my-other-pie');
       });
     });
 


### PR DESCRIPTION
Using the PIE definitions, generate a unique id that can be used by a developer to identify a unique combination of PIEs (and their versions) defined in config.json

` pie manifest-id `

