### PR TITLE
released versions should not depend on `develop` branch of pie-* dependencies

### DIFF
--- a/bin/pie
+++ b/bin/pie
@@ -6,4 +6,8 @@ let args = minimist(process.argv.slice(2));
 let logFactory = require('../lib/log-factory');
 let defaultLogConfig = require('../lib/log-config').default;
 logFactory.init(args.logLevel || args['log-level'] || defaultLogConfig);
-require('../lib/cli').default(args);
+require('../lib/cli').default(args)
+  .then(() => { })
+  .catch((e) => {
+    console.error(e);
+  });

--- a/src/apps/base/index.ts
+++ b/src/apps/base/index.ts
@@ -31,13 +31,7 @@ export function logBuild<T>(name: string, p: Promise<T>): Promise<T> {
   });
 }
 
-let clientDependencies = (branch: string) => {
-  return {
-    'pie-controller': `PieLabs/pie-controller#${branch}`,
-    'pie-player': `PieLabs/pie-player#${branch}`,
-    'pie-control-panel': `PieLabs/pie-control-panel#${branch}`
-  }
-}
+let clientDependencies = (args: any) => args.configuration.app.dependencies;
 
 type BuildNames = {
   entryFile: string;
@@ -246,7 +240,7 @@ export abstract class BaseApp implements App {
 
   protected async install(): Promise<void> {
     await this.allInOneBuild.install({
-      dependencies: clientDependencies(this.branch),
+      dependencies: clientDependencies(this.args),
       devDependencies: this.support.npmDependencies || {}
     });
   }

--- a/src/apps/base/index.ts
+++ b/src/apps/base/index.ts
@@ -119,7 +119,8 @@ export abstract class BaseApp implements App {
       config,
       support,
       this.names.build.entryFile,
-      this.names.out.completeItemTag.path);
+      this.names.out.completeItemTag.path,
+      this.args.writeWebpackConfig !== false);
   }
 
   protected logBuild(name: string): void {

--- a/src/apps/types.ts
+++ b/src/apps/types.ts
@@ -11,10 +11,13 @@ import * as http from 'http';
 
 export class BuildOpts {
   constructor(readonly clean: boolean = false,
-    readonly keepBuildAssets: boolean = false) { }
+    readonly keepBuildAssets: boolean = false
+  ) { }
 
   static build(args: any) {
-    return new BuildOpts(args.clean, args.keepBuildAssets === true);
+    return new BuildOpts(
+      args.clean,
+      args.keepBuildAssets === true);
   }
 }
 

--- a/src/cli/configuration.ts
+++ b/src/cli/configuration.ts
@@ -1,0 +1,17 @@
+/** 
+ * The default pie cli configuration object.
+ * This can be overridden by adding a `pie.config.json` in the target dir.
+ * Or by using `--config path/to/config/json`.
+ * 
+ * NOTE: Not going to add this to the cli docs for now as the only options that may be changed 
+ * are only really for those developing pie-cli or the listed dependencies below.
+ */
+export default {
+  app: {
+    dependencies: {
+      'pie-player': '~2.1.0',
+      'pie-controller': '~2.0.0',
+      'pie-control-panel': '~1.1.0'
+    }
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,9 +6,14 @@ import clean from './clean';
 import manifest from './manifest';
 import info from './info';
 import version from './version';
+import { readJsonSync, existsSync } from 'fs-extra';
+import configuration from './configuration';
+import { buildLogger } from '../log-factory';
 
 import { normalizeOpts } from './helper';
 import CliCommand from './cli-command';
+
+const logger = buildLogger();
 
 let commands: CliCommand[] = [
   pack,
@@ -19,9 +24,20 @@ let commands: CliCommand[] = [
   version
 ];
 
+export const PIE_CONFIG = 'pie.config.json';
+
+let loadConfig = (config?: string) => {
+  config = config || PIE_CONFIG;
+  return _.merge(configuration, existsSync(config) ? readJsonSync(config) : {});
+}
+
 export default function (opts) {
 
   opts = normalizeOpts(opts);
+  logger.info('opts:', opts);
+  opts.configuration = loadConfig(opts.config);
+
+  logger.info('opts:', opts);
 
   let help: CliCommand = new Help('pie', commands);
 
@@ -31,7 +47,7 @@ export default function (opts) {
 
   let result = cmd.run(opts);
 
-  (result || Promise.resolve('done!'))
+  return (result || Promise.resolve('done!'))
     .then((result) => {
       if (result) {
         console.log(result);

--- a/src/question/build/all-in-one.ts
+++ b/src/question/build/all-in-one.ts
@@ -25,9 +25,10 @@ export default class AllInOne {
     readonly config: JsonConfig,
     private supportConfig: SupportConfig,
     private entryPath: string,
-    readonly fileout: string) {
-    this.client = new ClientBuild(config, supportConfig.webpackLoaders(p => p));
-    this.controllers = new ControllersBuild(config);
+    readonly fileout: string,
+    private writeWebpackConfig: boolean) {
+    this.client = new ClientBuild(config, supportConfig.webpackLoaders(p => p), writeWebpackConfig);
+    this.controllers = new ControllersBuild(config, writeWebpackConfig);
   }
 
   async install(client: { dependencies: KeyMap, devDependencies: KeyMap }): Promise<any> {
@@ -84,8 +85,8 @@ export default class AllInOne {
     let m = config.module as any;
     m.loaders = (m.loaders || []).concat(this.supportConfig.webpackLoaders(p => p));
 
-    if (process.env.WRITE_WEBPACK_CONFIG) {
-      writeConfig(join(this.config.dir, 'all-in-one.webpack-config.js'), config);
+    if (this.writeWebpackConfig) {
+      writeConfig(join(this.config.dir, '.all-in-one.webpack.config.js'), config);
     }
 
     return config;

--- a/src/question/build/client.ts
+++ b/src/question/build/client.ts
@@ -11,6 +11,7 @@ import { writeFileSync } from 'fs-extra';
 import { build as buildWebpack, BuildResult } from '../../code-gen/webpack-builder';
 import * as webpack from 'webpack';
 import { buildLogger } from '../../log-factory';
+import { writeConfig } from '../../code-gen/webpack-write-config';
 
 const logger = buildLogger();
 
@@ -18,7 +19,7 @@ export default class ClientBuild {
 
   private npmDir: NpmDir;
 
-  constructor(private config: JsonConfig, readonly loaders: LoaderInfo[]) {
+  constructor(private config: JsonConfig, readonly loaders: LoaderInfo[], private writeWebpackConfig: boolean) {
     this.npmDir = new NpmDir(this.config.dir);
   }
 
@@ -61,6 +62,11 @@ export default class ClientBuild {
 
     let m = config.module as any;
     m.loaders = (m.loaders || []).concat(this.loaders);
+
+    if (this.writeWebpackConfig) {
+      writeConfig(join(this.config.dir, '.client.webpack.config.js'), config);
+    }
+
     return config;
   }
 }

--- a/src/question/build/controllers.ts
+++ b/src/question/build/controllers.ts
@@ -9,6 +9,7 @@ import baseConfig from './base-config';
 import { writeFileSync } from 'fs-extra';
 import { build as buildWebpack, BuildResult } from '../../code-gen/webpack-builder';
 import * as webpack from 'webpack';
+import { writeConfig } from '../../code-gen/webpack-write-config';
 
 const logger = buildLogger();
 
@@ -18,7 +19,7 @@ export default class ControllersBuild {
 
   private npmDir: NpmDir;
 
-  constructor(private config: JsonConfig) {
+  constructor(private config: JsonConfig, private writeWebpackConfig: boolean) {
     ensureDirSync(this.controllersDir);
     this.npmDir = new NpmDir(this.controllersDir);
   }
@@ -66,7 +67,7 @@ export default class ControllersBuild {
   }
 
   private _config(fileout: string, libraryName: string) {
-    return _.extend({
+    let config = _.extend({
       context: this.controllersDir,
       entry: this.entryJsPath,
       output: {
@@ -75,5 +76,11 @@ export default class ControllersBuild {
         libraryTarget: 'umd'
       }
     }, baseConfig(this.controllersDir));
+
+    if (this.writeWebpackConfig) {
+      writeConfig(join(this.config.dir, '.controllers.webpack.config.js'), config);
+    }
+
+    return config;
   }
 }

--- a/test/unit/apps/base/index-test.js
+++ b/test/unit/apps/base/index-test.js
@@ -72,7 +72,13 @@ describe('BaseApp', function () {
 
     BaseApp = mod.BaseApp;
     names = mod.getNames({});
-    app = new BaseApp({}, jsonConfig, supportConfig, names);
+    app = new BaseApp({
+      configuration: {
+        app: {
+          dependencies: {}
+        }
+      }
+    }, jsonConfig, supportConfig, names);
   });
 
   describe('constructor', () => {

--- a/test/unit/cli/index-test.js
+++ b/test/unit/cli/index-test.js
@@ -1,0 +1,103 @@
+import { expect } from 'chai';
+import { stub, match, assert, spy } from 'sinon';
+import proxyquire from 'proxyquire';
+
+const ROOT = '../../../lib';
+
+let cmdStub = () => {
+  return {
+    match: stub().returns(true),
+    run: stub().returns(Promise.resolve('done'))
+  }
+}
+
+let defaultCmdStub = () => {
+  return {
+    default: cmdStub()
+  }
+}
+
+describe('cli', () => {
+  let mod, deps, help;
+
+  beforeEach(() => {
+
+    help = cmdStub();
+    deps = {
+      'fs-extra': {
+        existsSync: stub(),
+        readJsonSync: stub()
+      },
+      './info': defaultCmdStub(),
+      './help': {
+        Help: stub().returns(help)
+      },
+      './version': defaultCmdStub(),
+      './clean': defaultCmdStub(),
+      './pack': defaultCmdStub(),
+      './serve': defaultCmdStub(),
+      './manifest': defaultCmdStub(),
+      './configuration': {
+        default: {
+          app: {
+            dependencies: {
+              a: '1.0.0'
+            }
+          }
+        }
+      }
+    }
+
+    mod = proxyquire(`${ROOT}/cli`, deps);
+  });
+
+  describe('default', () => {
+
+    it('tries to load pie.config.json', () => {
+      return mod.default({}).then(() => {
+        assert.calledWith(deps['fs-extra'].existsSync, mod.PIE_CONFIG);
+      });
+    });
+
+    it('tries to load other config file name', () => {
+      return mod.default({ config: 'some-other.config.json' }).then(() => {
+        assert.calledWith(deps['fs-extra'].existsSync, 'some-other.config.json');
+      });
+    });
+
+    it('uses the default config if it cant load the json', () => {
+      return mod.default({}).then(() => {
+        assert.calledWith(help.run, {
+          configuration: {
+            app: {
+              dependencies: {
+                a: '1.0.0'
+              }
+            }
+          }
+        });
+      });
+    });
+
+    it('merges the loaded config with the default config', () => {
+
+      deps['fs-extra'].existsSync.returns(true);
+      deps['fs-extra'].readJsonSync.returns({
+        app: {
+          dependencies: {
+            b: '1.0.0'
+          }
+        }
+      });
+
+      let dependencies = { a: '1.0.0', b: '1.0.0' }
+      return mod.default().then(() => {
+        configuration: {
+          app: {
+            dependencies: dependencies
+          }
+        }
+      });
+    });
+  });
+});

--- a/test/unit/question/build/all-in-one-test.js
+++ b/test/unit/question/build/all-in-one-test.js
@@ -27,6 +27,7 @@ describe('all-in-one', () => {
         instance: controllers,
         default: stub().returns(controllers)
       }
+
     };
 
     supportConfig = {
@@ -106,10 +107,8 @@ describe('all-in-one', () => {
   });
 
   describe('build', () => {
-    beforeEach((done) => {
-      instance.build('//js...')
-        .then(() => done())
-        .catch(done);
+    beforeEach(() => {
+      return instance.build('//js...');
     });
 
     it('calls writeFileSync', () => {
@@ -118,6 +117,18 @@ describe('all-in-one', () => {
 
     it('calls buildWebpack', () => {
       assert.calledWith(mod.deps('webpack-builder').build, expectedConfig);
+    });
+
+    describe('with writeWebpackConfig', () => {
+      beforeEach(() => {
+        instance = new AllInOne(jsonConfig, supportConfig, 'entry.js', 'fileout.js', true);
+        return instance.build('//js...');
+      });
+
+      it('calls writeWebpackConfig', () => {
+        let configPath = path.join('dir', '.all-in-one.webpack.config.js');
+        assert.calledWith(mod.deps('webpack-write-config').writeConfig, configPath, match.object);
+      });
     });
   });
 

--- a/test/unit/question/build/client-test.js
+++ b/test/unit/question/build/client-test.js
@@ -31,11 +31,7 @@ describe('ClientBuild', () => {
 
   describe('install', () => {
 
-    beforeEach((done) => {
-      instance.install()
-        .then(() => done())
-        .catch(done);
-    });
+    beforeEach(() => instance.install());
 
     it('calls npmDir.install', () => {
       assert.calledWith(mod.deps('npm-dir').instance.install,
@@ -48,14 +44,7 @@ describe('ClientBuild', () => {
 
   describe('build', () => {
     let result;
-    beforeEach((done) => {
-      instance.build('//js..', 'out.js')
-        .then((r) => {
-          result = r;
-          done()
-        })
-        .catch(done);
-    });
+    beforeEach(() => instance.build('//js..', 'out.js').then(r => result = r));
 
     it('calls fs-extra writeFileSync', () => {
       let writeFileSync = mod.deps('fs-extra').writeFileSync;
@@ -73,6 +62,17 @@ describe('ClientBuild', () => {
 
     it('calls buildWebpack', () => {
       assert.calledWith(mod.deps('webpack-builder').build, expectedConfig);
+    });
+
+    describe('with writeWebpackConfig=true', () => {
+
+      it('calls buildWebpack', () => {
+        instance = new ClientBuild({ dir: 'dir' }, [], true);
+        return instance.build('//js..', 'out.js')
+          .then(() => {
+            assert.calledWith(mod.deps('webpack-write-config').writeConfig, 'dir/.client.webpack.config.js', match.object);
+          });
+      });
     });
   });
 

--- a/test/unit/question/build/controllers-test.js
+++ b/test/unit/question/build/controllers-test.js
@@ -32,14 +32,7 @@ describe('ControllersBuild', () => {
 
     let result;
 
-    beforeEach((done) => {
-      instance.build('out.js', 'lib')
-        .then(r => {
-          result = r;
-          done();
-        })
-        .catch(done);
-    });
+    beforeEach(() => instance.build('out.js', 'lib').then(r => result = r));
 
     it('writes out the entry.js', () => {
       assert.calledWith(
@@ -59,14 +52,22 @@ describe('ControllersBuild', () => {
     it('returns the filename', () => {
       expect(result).to.eql('out.js');
     });
+
+
+    describe('with writeWebpackConfig=true', () => {
+
+      it('calls buildWebpack', () => {
+        instance = new ControllersBuild({ dir: 'dir' }, true);
+        return instance.build('out.js', 'lib')
+          .then(() => {
+            assert.calledWith(mod.deps('webpack-write-config').writeConfig, 'dir/.controllers.webpack.config.js', match.object);
+          });
+      });
+    });
   });
 
   describe('install', () => {
-    beforeEach((done) => {
-      instance.install()
-        .then(() => done())
-        .catch(done);
-    });
+    beforeEach(() => instance.install());
 
     it('calls npmDir.install', () => {
       assert.calledWith(

--- a/test/unit/question/build/stubs.js
+++ b/test/unit/question/build/stubs.js
@@ -27,6 +27,9 @@ export function stubs(path, deps) {
     '../../code-gen/webpack-builder': {
       build: stub().returns({ duration: 1000 })
     },
+    '../../code-gen/webpack-write-config': {
+      writeConfig: stub()
+    },
     '../../npm/npm-dir': {
       instance: npmDir,
       default: stub().returns(npmDir)


### PR DESCRIPTION
the program is configured to automatically depend on the following: `pie-control-panel`, `pie-player` and `pie-controller` using the `#develop` branch. This is fine for a non released version of the cli - but for the released version these should be locked down to versions.