### PR TITLE
Legacy support no longer added to corespring-XXX-ng15 items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pie",
-  "version": "5.1.0-prerelease",
+  "version": "5.0.1-prerelease",
   "description": "The Portable Interaction Elements framework CLI",
   "preferGlobal": true,
   "bin": {

--- a/src/apps/load-app.ts
+++ b/src/apps/load-app.ts
@@ -2,7 +2,6 @@ import { App, DefaultApp, InfoApp } from './types';
 import { JsonConfig } from '../question/config';
 import { BuildConfig, react, less, legacySupport } from '../framework-support';
 import * as _ from 'lodash';
-import { info } from '../package-info';
 import { buildLogger } from '../log-factory';
 
 const logger = buildLogger();
@@ -18,26 +17,14 @@ export default async function loadApp(args: any): Promise<App> {
    * prepare support config using the Apps config object.
    */
   let loadSupportConfig = (config) => {
-    let deps = _(config.dependencies)
-      .map((value, key) => {
-        return { key: key, value: value };
-      })
-      .map(kv => info(kv, 'dependencies', config.dir))
-      .value();
+    let legacy = legacySupport(config.dependencies)
+    let supportInfo = [react, less];
 
-    return Promise.all(deps)
-      .then((results) => {
-        logger.silly('dependencies: ', JSON.stringify(results, null, '  '));
-        let merged = _.reduce(results, _.merge, {});
-        logger.silly('merged: ', JSON.stringify(merged, null, '  '));
-        let legacy = legacySupport(merged)
-        let supportInfo = [react, less];
-
-        if (legacy) {
-          supportInfo.push(legacy);
-        }
-        return new BuildConfig(supportInfo);
-      });
+    if (legacy) {
+      supportInfo.push(legacy);
+    }
+    let cfg = new BuildConfig(supportInfo);
+    return Promise.resolve(cfg);
   };
 
   let appKey = args.app || args.a || 'default';

--- a/test/unit/apps/load-app-test.js
+++ b/test/unit/apps/load-app-test.js
@@ -18,9 +18,6 @@ describe('loadApp', () => {
 
   beforeEach((done) => {
     deps = {
-      '../package-info': {
-        info: stub()
-      },
       '../framework-support': {
         legacySupport: stub(),
         react: 'react',
@@ -67,27 +64,14 @@ describe('loadApp', () => {
     };
 
     describe('loadSupportConfig', () => {
-      beforeEach(() => {
-        deps['../package-info'].info
-          .onFirstCall().returns({ b: '1.0.0' })
-          .onSecondCall().returns({ c: '2.0.0' });
-      });
 
       describe('with no legacy', () => {
         beforeEach((done) => {
           load(done);
         });
 
-        it('calls info for 1st dependency', () => {
-          assert.calledWith(deps['../package-info'].info, { key: 'a', value: '1.0.0' }, 'dependencies', 'dir')
-        });
-
-        it('calls info for 2nd dependency', () => {
-          assert.calledWith(deps['../package-info'].info, { key: 'aa', value: '1.0.0' }, 'dependencies', 'dir')
-        });
-
         it('calls legacySupport', () => {
-          assert.calledWith(deps['../framework-support'].legacySupport, { b: '1.0.0', c: '2.0.0' });
+          assert.calledWith(deps['../framework-support'].legacySupport, { a: '1.0.0', aa: '1.0.0' });
         });
 
         it('calls new BuildConfig', () => {


### PR DESCRIPTION
Looks like with the new structure of PIE config, we're not seeing the `corespring-XXX-ng15` values in the dependencies field of config. It now looks like this for a `corespring-function-entry-ng15` PIE, for example:

    {
      "corespring-legacy-function-entry": "corespring/corespring-legacy-function-entry",
      "less": "^2.7.1",
      "lodash": "^4.15.0"
    }

Going to change this so that it looks at the `elements` field of the `config` object to determine whether there are any legacy interactions.