### PR TITLE
commands fail if run against an existing node_modules dir

### DIFF
--- a/local-typings/archiver/index.d.ts
+++ b/local-typings/archiver/index.d.ts
@@ -40,6 +40,7 @@ declare namespace archiver {
 
     bulk(mappings: any): void;
     finalize(): void;
+    //glob(g: string): void;
   }
 
   export interface Options {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pie",
-  "version": "5.3.0-prerelease",
+  "version": "5.2.1-prerelease",
   "description": "The Portable Interaction Elements framework CLI",
   "preferGlobal": true,
   "bin": {
@@ -36,7 +36,6 @@
   "devDependencies": {
     "@types/acorn": "^4.0.0",
     "@types/ajv": "1.0.0",
-    "@types/archiver": "^0.15.36",
     "@types/babel-core": "^6.7.14",
     "@types/chokidar": "^1.4.31",
     "@types/ejs": "^2.3.33",
@@ -49,7 +48,6 @@
     "@types/pug": "^2.0.4",
     "@types/resolve": "0.0.4",
     "@types/semver": "^5.3.30",
-    "@types/sockjs": "^0.3.30",
     "@types/source-map": "^0.5.0",
     "@types/stack-trace": "0.0.28",
     "@types/temp": "^0.8.29",

--- a/src/apps/base/index.ts
+++ b/src/apps/base/index.ts
@@ -1,4 +1,4 @@
-import { App, BuildOpts, BuildResult, ManifestOpts } from '../types';
+import { App, ServeOpts, BuildOpts, BuildResult, ManifestOpts } from '../types';
 import { JsonConfig, Manifest, Declaration, ElementDeclaration } from '../../question/config';
 import AllInOneBuild, { ClientBuild, ControllersBuild, SupportConfig } from '../../question/build/all-in-one';
 import { KeyMap } from '../../npm/types';
@@ -188,7 +188,7 @@ export abstract class BaseApp implements App {
 
   async build(opts: BuildOpts): Promise<string[]> {
 
-    await logBuild('install', this.install());
+    await logBuild('install', this.install(opts.forceInstall));
 
     let files = await _.reduce(this.buildSteps, (acc, bs) => {
       return acc.then(f => {
@@ -205,8 +205,8 @@ export abstract class BaseApp implements App {
 
   protected abstract mkServer(app: express.Application): ReloadOrError & HasServer;
 
-  async server(): Promise<{ server: http.Server, reload: (string) => void }> {
-    await logBuild('install', this.install());
+  async server(opts: ServeOpts): Promise<{ server: http.Server, reload: (string) => void }> {
+    await logBuild('install', this.install(opts.forceInstall));
     let src = this.prepareWebpackJs();
     let config = this.allInOneBuild.webpackConfig(src);
     let compiler = webpack(config);
@@ -286,11 +286,11 @@ export abstract class BaseApp implements App {
     return router;
   }
 
-  protected async install(): Promise<void> {
+  protected async install(force: boolean): Promise<void> {
     await this.allInOneBuild.install({
       dependencies: clientDependencies(this.args),
       devDependencies: this.support.npmDependencies || {}
-    });
+    }, force);
   }
 
   async manifest(opts: ManifestOpts): Promise<Manifest> {

--- a/src/apps/info/index.ts
+++ b/src/apps/info/index.ts
@@ -8,7 +8,7 @@ import { SupportConfig } from '../../framework-support';
 import * as _ from 'lodash';
 import { join, resolve } from 'path';
 import * as pug from 'pug';
-import { writeFileSync, writeJsonSync, readJsonSync, readFileSync } from 'fs-extra';
+import { existsSync, writeFileSync, writeJsonSync, readJsonSync, readFileSync } from 'fs-extra';
 import * as jsesc from 'jsesc';
 import { install as bowerInstall } from './bower';
 import loadSchemas from './schema-loader';
@@ -18,7 +18,6 @@ import * as express from 'express';
 import { BaseApp, Tag, Out, Names, Compiler, build as buildApp, getNames } from '../base';
 import { ReloadOrError, HasServer } from '../server/types';
 import * as http from 'http';
-import { existsSync } from 'fs-extra';
 
 const logger = buildLogger();
 const templatePath = join(__dirname, 'views/index.pug');
@@ -42,14 +41,13 @@ export default class InfoApp extends BaseApp {
 
   constructor(args: any, private pieRoot: string, config: JsonConfig, support: SupportConfig, names: Names) {
     super(args, config, support, names);
-    logger.debug('new InfoApp..');
     this.template = pug.compileFile(templatePath, { pretty: true });
   }
 
-  protected async install(): Promise<void> {
-    logger.silly('super install...');
-    await super.install();
-    logger.silly('bower install...');
+  protected async install(forceInstall: boolean): Promise<void> {
+    logger.silly(`[install] forceInstall: ${forceInstall}`);
+    await super.install(forceInstall);
+    logger.silly('[install] bower install...');
     await bowerInstall(this.config.dir, ['PieLabs/pie-component-page#update']);
   }
 

--- a/src/apps/types.ts
+++ b/src/apps/types.ts
@@ -13,26 +13,31 @@ import * as http from 'http';
 export class BuildOpts {
   constructor(readonly clean: boolean = false,
     readonly keepBuildAssets: boolean = false,
-    readonly createArchive: boolean = false
+    readonly createArchive: boolean = false,
+    readonly forceInstall: boolean = false
   ) { }
 
   static build(args: any) {
     return new BuildOpts(
       args.clean,
       args.keepBuildAssets === true,
-      args.createArchive === true);
+      args.createArchive === true,
+      args.forceInstall === true);
   }
 }
 
 export class ServeOpts {
-  constructor(readonly dir, readonly clean, readonly port) { }
+  constructor(
+    readonly dir: string,
+    readonly port: number,
+    readonly forceInstall: boolean) { }
 
   static build(args) {
     args = args || {};
     return new ServeOpts(
       args.dir || process.cwd(),
-      args.clean === 'true' || args.clean === true || false,
-      args.port || 4000)
+      args.port || 4000,
+      args.forceInstall === true)
   }
 }
 

--- a/src/npm/npm-dir.ts
+++ b/src/npm/npm-dir.ts
@@ -12,18 +12,16 @@ export default class NpmDir {
     logger.debug(`rootDir: ${rootDir}`);
   }
 
-  install(name: string, dependencies: KeyMap, devDeps: KeyMap) {
+  install(name: string, dependencies: KeyMap, devDeps: KeyMap, force: boolean) {
     logger.info('[install] ...');
     return this._writePackageJson(name, dependencies, devDeps)
-      .then(() => this._install());
-    //TODO - useful to dedupe?
-    //.then(() => this._dedupe());
+      .then(() => this._install(force));
   };
 
   ls() {
     logger.info('[ls]');
     if (!this._installed) {
-      return this._install()
+      return this._install(false)
         .then(() => this.ls())
     } else {
       return this._spawnPromise(['ls', '--json'], true)
@@ -67,11 +65,17 @@ export default class NpmDir {
     return spawnPromise('npm', this.rootDir, ['dedupe'], false);
   }
 
-  private _install(args?: any[]) {
-    args = args || [];
-    let cmd = ['install'].concat(args);
-    logger.silly('[install] > final cmd: ', cmd.join(' '));
-    return this._spawnPromise(cmd);
+  private _install(force: boolean, args?: any[]) {
+    logger.silly(`[_install], force: ${force}, args: ${args}`);
+    if (this._installed && !force) {
+      logger.debug(`[_install] node_modules exists - skipping install.`);
+      return Promise.resolve({ stdout: 'skipped' });
+    } else {
+      args = args || [];
+      let cmd = ['install'].concat(args);
+      logger.silly('[_install] > final cmd: ', cmd.join(' '));
+      return this._spawnPromise(cmd);
+    }
   };
 
 

--- a/src/question/build/all-in-one.ts
+++ b/src/question/build/all-in-one.ts
@@ -33,9 +33,9 @@ export default class AllInOne {
     this.writtenWebpackConfig = '.all-in-one.webpack.config.js';
   }
 
-  async install(client: { dependencies: KeyMap, devDependencies: KeyMap }): Promise<any> {
-    await this.client.install(client.dependencies, client.devDependencies);
-    await this.controllers.install();
+  async install(client: { dependencies: KeyMap, devDependencies: KeyMap }, force: boolean): Promise<any> {
+    await this.client.install(client.dependencies, client.devDependencies, force);
+    await this.controllers.install(force);
   }
 
 

--- a/src/question/build/client.ts
+++ b/src/question/build/client.ts
@@ -53,11 +53,17 @@ export default class ClientBuild {
   }
 
   private _config(fileout: string): webpack.Configuration {
-    let config = _.extend({
+
+    let override = {
       context: this.config.dir,
       entry: this.entryJsPath,
-      output: { filename: fileout, path: this.config.dir }
-    }, baseConfig(this.config.dir));
+      output: { filename: fileout, path: this.config.dir },
+      resolve: {
+        extensions: ['.js', '.jsx']
+      }
+    }
+
+    let config = _.merge(baseConfig(this.config.dir), override);
 
     config.module.rules = (config.module.rules || []).concat(this.rules);
 

--- a/src/question/build/client.ts
+++ b/src/question/build/client.ts
@@ -29,10 +29,10 @@ export default class ClientBuild {
     });
   }
 
-  async install(deps: KeyMap, devDeps: KeyMap): Promise<void> {
+  async install(deps: KeyMap, devDeps: KeyMap, force: boolean): Promise<void> {
     deps = _.merge(this.config.dependencies, deps);
     devDeps = _.merge(devDeps, this.clientDevDeps);
-    await this.npmDir.install('tmp-client-package', deps, devDeps);
+    await this.npmDir.install('tmp-client-package', deps, devDeps, force);
   }
 
   get entryJsPath(): string {

--- a/src/question/build/controllers.ts
+++ b/src/question/build/controllers.ts
@@ -38,10 +38,10 @@ export default class ControllersBuild {
     return out;
   }
 
-  async install(): Promise<void> {
+  async install(force: boolean): Promise<void> {
     //Note: We need to install using the *-controller name.
     let installDependencies = _.mapKeys(this.controllerDependencies, (value, key) => `${key}-controller`);
-    await this.npmDir.install('tmp-controllers-package', installDependencies, {});
+    await this.npmDir.install('tmp-controllers-package', installDependencies, {}, force);
   }
 
   get entryJs() {

--- a/test/unit/apps/base/index-test.js
+++ b/test/unit/apps/base/index-test.js
@@ -113,11 +113,12 @@ describe('BaseApp', function () {
 
   describe('build', () => {
 
-    let run = (keepBuildAssets) => {
+    let run = (keepBuildAssets, forceInstall) => {
+      forceInstall = forceInstall === undefined ? false : forceInstall;
       app.install = stub().returns(Promise.resolve());
       app.buildAllInOne = stub().returns(Promise.resolve([]));
       app.removeBuildAssets = stub().returns(Promise.resolve([]))
-      return app.build({ keepBuildAssets: keepBuildAssets })
+      return app.build({ keepBuildAssets, forceInstall })
         .then(r => result = r);
     }
 
@@ -125,7 +126,7 @@ describe('BaseApp', function () {
       beforeEach(() => run(false));
 
       it('calls install', () => {
-        assert.called(app.install);
+        assert.calledWith(app.install, false);
       });
 
       it('calls buildAllInOne', () => {
@@ -134,6 +135,13 @@ describe('BaseApp', function () {
 
       it('calls removeBuildAssets', () => {
         assert.calledOnce(app.removeBuildAssets);
+      });
+    });
+
+    describe('with forceInstall', () => {
+      beforeEach(() => run(false, true));
+      it('calls install with forceInstal = true', () => {
+        assert.calledWith(app.install, true);
       });
     });
 
@@ -148,6 +156,11 @@ describe('BaseApp', function () {
 
   describe('server', () => {
 
+    let run = (forceInstall) => {
+      forceInstall = forceInstall === undefined ? false : forceInstall;
+      return app.server({ forceInstall }).then(r => result = r);
+    }
+
     beforeEach(() => {
       app.install = stub().returns(Promise.resolve());
       app.prepareWebpackJs = stub().returns('');
@@ -157,12 +170,15 @@ describe('BaseApp', function () {
       app.router = stub().returns({ router: true });
       app._linkCompilerToServer = stub();
       app.mkServer = stub().returns({ server: true, httpServer: {} });
-      return app.server().then(r => result = r);
     });
+
+    beforeEach(() => run());
 
     it('calls install', () => {
       assert.calledOnce(app.install);
+      assert.calledWith(app.install, false);
     });
+
 
     it('calls prepareWebpackJs', () => {
       assert.calledOnce(app.prepareWebpackJs);
@@ -202,6 +218,14 @@ describe('BaseApp', function () {
 
     it('returns reload', () => {
       expect(_.isFunction(result.reload)).to.be.true;
+    });
+
+    describe('with forceInstall = true', () => {
+      beforeEach(() => run(true));
+
+      it('calls install with forceInstall = true', () => {
+        assert.calledWith(app.install, true);
+      });
     });
 
     describe('reload handler', () => {

--- a/test/unit/npm/npm-dir-test.js
+++ b/test/unit/npm/npm-dir-test.js
@@ -63,7 +63,24 @@ describe('npm-dir', () => {
     });
 
     it('calls \'npm install\' in a child_process', () => {
+      fs.existsSync.returns(false);
       return dir.install({})
+        .then(() => {
+          assert.calledWith(io.spawnPromise, 'npm', __dirname, ['install'], false);
+        });
+    });
+
+    it('skips calling \'npm install\' in a child_process if node_modules exists', () => {
+      fs.existsSync.returns(true);
+      return dir.install({})
+        .then(() => {
+          assert.notCalled(io.spawnPromise);
+        });
+    });
+
+    it('calls \'npm install\' in a child_process if node_modules exists and force = true', () => {
+      fs.existsSync.returns(true);
+      return dir.install('name', {}, {}, true)
         .then(() => {
           assert.calledWith(io.spawnPromise, 'npm', __dirname, ['install'], false);
         });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,10 +7,13 @@
     "preserveConstEnums": true,
     "sourceMap": true,
     "outDir": "lib/",
-    "target": "es6"
+    "target": "es6",
+    "typeRoots": [
+      "./node_modules/@types",
+      "./local-typings"
+    ]
   },
   "include": [
-    "src/**/*",
-    "local-typings/**/*"
+    "src/**/*"
   ]
 }


### PR DESCRIPTION
If you run a command for a question where no build assets have been installed (aka node_modules), then the command completes successfully. If you then re-run the command, it'll try and re-use the existing build assets, this can often fail. I suspect this has something to do with re-running `npm install`

Note: It doesn't affect all pies, just some. 

Steps to reproduce: 

```shell
git clone git@github.com:PieLabs/pie-toggle.git
cd pie-toggle/docs/demo
pie serve
# Ctrl+c to stop serving
pie serve
```

Expected: The toggle demo runs on localhost:4000
Actual: Webpack fails saying it's missing modules (see below). Toggle doesnt render.


Workaround: `pie clean` or `rm -fr node_modules` the run `pie serve` again.

```shell
ERROR in ./~/recompose/shouldUpdate.js
Module not found: Error: Can't resolve 'react' in '/mnt/biggie-one/dev/github/PieLabs/pie-toggle/docs/demo/node_modules/recompose'
 @ ./~/recompose/shouldUpdate.js 5:13-29
 @ ./~/recompose/pure.js
 @ ./~/pie-control-panel/~/material-ui/svg-icons/navigation/check.js
 @ ./~/pie-control-panel/~/material-ui/MenuItem/MenuItem.js
 @ ./~/pie-control-panel/~/material-ui/MenuItem/index.js
 @ ./~/pie-control-panel/lib/choice-group.jsx
 @ ./~/pie-control-panel/lib/control-panel.jsx
 @ ./~/pie-control-panel/lib/index.js
 @ ./.all-in-one.entry.js

``