### PR TITLE
114 - webpack watch triggering multiple compiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,11 +61,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.0",
     "babel-register": "^6.24.0",
     "chai": "^3.5.0",
-    "eslint": "^3.17.1",
-    "eslint-plugin-react": "^6.10.0",
-    "expand-home-dir": "0.0.3",
     "gulp": "^3.9.1",
-    "gulp-eslint": "^3.0.1",
     "gulp-git": "^2.1.0",
     "gulp-mocha": "^4.1.0",
     "gulp-sourcemaps": "^2.4.1",
@@ -110,8 +106,7 @@
     "semver": "^5.3.0",
     "sockjs": "^0.3.18",
     "touch": "^1.0.0",
-    "webpack": "2.2.1",
-    "webpack-dev-middleware": "^1.10.1",
-    "winston": "^2.3.1"
+    "webpack": "^2.3.2",
+    "webpack-dev-middleware": "^1.10.1"
   }
 }

--- a/src/apps/info/index.ts
+++ b/src/apps/info/index.ts
@@ -6,8 +6,9 @@ import * as webpackMiddleware from 'webpack-dev-middleware';
 
 import { App, Servable, ServeOpts, ServeResult } from '../types';
 import AppServer, { linkCompilerToServer } from '../../server';
-import { existsSync, readFileSync, readJsonSync, writeFileSync } from 'fs-extra';
+import { existsSync, readFileSync, readJsonSync } from 'fs-extra';
 import { join, resolve } from 'path';
+import { writeConfig, writeEntryJs } from '../../code-gen';
 
 import Install from '../../install';
 import { JsonConfig } from '../../question/config';
@@ -15,7 +16,6 @@ import { SupportConfig } from './../../framework-support';
 import { buildLogger } from 'log-factory';
 import entryJs from './entry';
 import { webpackConfig } from '../common';
-import { writeConfig } from '../../code-gen/webpack-write-config';
 
 const logger = buildLogger();
 const templatePath = join(__dirname, 'views/index.pug');
@@ -75,7 +75,8 @@ export default class InfoApp implements App, Servable {
       mappings,
       AppServer.SOCK_PREFIX);
 
-    writeFileSync(join(this.installer.dir, InfoApp.ENTRY), js, 'utf8');
+    await writeEntryJs(join(this.installer.dir, InfoApp.ENTRY), js);
+
     const config = webpackConfig(this.installer, this.support, InfoApp.ENTRY, InfoApp.BUNDLE);
 
     const cssRule = config.module.rules.find((r) => {

--- a/src/apps/item/index.ts
+++ b/src/apps/item/index.ts
@@ -14,7 +14,7 @@ import { SupportConfig } from '../../framework-support';
 import { buildLogger } from 'log-factory';
 import entryJs from './entry';
 import { webpackConfig } from '../common';
-import { writeConfig } from '../../code-gen/webpack-write-config';
+import { writeConfig, writeEntryJs } from '../../code-gen';
 import { writeFileSync } from 'fs-extra';
 
 const logger = buildLogger();
@@ -63,7 +63,7 @@ export default class ItemApp implements App, Servable {
       mappings.controllers,
       AppServer.SOCK_PREFIX);
 
-    writeFileSync(join(this.installer.dirs.root, ItemApp.ENTRY), js, 'utf8');
+    await writeEntryJs(join(this.installer.dirs.root, ItemApp.ENTRY), js);
 
     logger.info('add sourceMaps? ', opts.sourceMaps);
 

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -57,7 +57,6 @@ export function linkCompilerToServer(name: string,
    * TODO:  This shouldn't be necessary but something is causing webpack to recompile repeatedly.
    * For now we debounce the done handler.
    */
-  compiler.plugin('compile', _.debounce(onCompile, 450, { leading: true, trailing: false }));
-  const debouncedOnDone = _.debounce(onDone, 450, { leading: false, trailing: true });
-  compiler.plugin('done', debouncedOnDone);
+  compiler.plugin('compile', onCompile);
+  compiler.plugin('done', onDone);
 }

--- a/test/unit/apps/item/index-test.js
+++ b/test/unit/apps/item/index-test.js
@@ -7,8 +7,8 @@ import proxyquire from 'proxyquire';
 
 const ROOT = '../../../../lib';
 
-describe('info app', () => {
-  let InfoApp, instance, mod, args, deps, config, supportConfig, middlewareInstance, routerInstance, express, compiler;
+describe('item app', () => {
+  let ItemApp, instance, mod, args, deps, config, supportConfig, middlewareInstance, routerInstance, express, compiler;
 
   beforeEach(() => {
 
@@ -63,9 +63,9 @@ describe('info app', () => {
       }
     }
 
-    mod = proxyquire(`${ROOT}/apps/info`, deps);
+    mod = proxyquire(`${ROOT}/apps/item`, deps);
 
-    InfoApp = mod.default;
+    ItemApp = mod.default;
 
     args = {};
 
@@ -83,7 +83,7 @@ describe('info app', () => {
       }
     };
 
-    instance = new InfoApp(args, 'pie-root', config, supportConfig);
+    instance = new ItemApp(args, config, supportConfig);
   });
 
   describe('constructor', () => {
@@ -116,11 +116,11 @@ describe('info app', () => {
     });
 
     it('calls writeEntryJs', () => {
-      assert.calledWith(deps['../../code-gen'].writeEntryJs, '.pie/info.entry.js', match.string);
+      assert.calledWith(deps['../../code-gen'].writeEntryJs, 'dir/item.entry.js', match.string);
     });
 
     it('calls webpackConfig', () => {
-      assert.calledWith(deps['../common'].webpackConfig, match.object, match.object, 'info.entry.js', 'info.bundle.js');
+      assert.calledWith(deps['../common'].webpackConfig, match.object, match.object, 'item.entry.js', 'item.bundle.js');
     });
 
     it('calls webpack', () => {
@@ -177,13 +177,6 @@ describe('info app', () => {
         assert.called(instance.template);
       });
 
-      it('calls readJsonSync for package.json', () => {
-        assert.calledWith(deps['fs-extra'].readJsonSync, 'pie-root/package.json');
-      });
-
-      it('calls readFileSync for README.md', () => {
-        assert.calledWith(deps['fs-extra'].readFileSync, 'pie-root/README.md');
-      });
     });
   });
 });


### PR DESCRIPTION
Caused by: https://github.com/webpack/watchpack/issues/25

Added the workaround suggested of backdating the file time.