### PR TITLE
fix(support): framework specific extensions are loaded by their modules

### DIFF
--- a/src/apps/common.ts
+++ b/src/apps/common.ts
@@ -80,7 +80,7 @@ export function webpackConfig(
       path: outpath
     },
     resolve: {
-      extensions: ['.js', '.jsx'],
+      extensions: _.uniq(['.js'].concat(support.extensions)),
       modules: resolveModules,
     },
     resolveLoader: {

--- a/test/unit/apps/common-test.js
+++ b/test/unit/apps/common-test.js
@@ -34,7 +34,8 @@ describe('common', () => {
     }
 
     support = {
-      rules: []
+      rules: [],
+      extensions: ['.support-extension']
     }
 
     mod = proxyquire('../../../lib/apps/common', deps);
@@ -67,6 +68,13 @@ describe('common', () => {
         'node_modules',
         resolve(join(__dirname, '../../../node_modules'))
       ])
+    });
+
+    it('adds extensions', () => {
+      expect(config.resolve.extensions).to.eql([
+        '.js',
+        '.support-extension'
+      ]);
     });
 
     it('adds devtool: eval if sourceMaps is true', () => {

--- a/test/unit/framework-support/index-test.js
+++ b/test/unit/framework-support/index-test.js
@@ -84,7 +84,62 @@ describe('framework-support', () => {
     });
   });
 
-  xdescribe('load', () => {
-    it('loads from package', () => { });
+  describe('load', () => {
+
+    let moduleRequire, result, moduleData;
+
+    describe('with no data', () => {
+      beforeEach(() => {
+        moduleData = {};
+        moduleRequire = stub().returns(moduleData);
+        return mod.load({}, 'path', moduleRequire)
+          .then(r => result = r);
+      });
+
+      it('returns empty extensions', () => {
+        expect(result.extensions).to.eql([])
+      });
+
+      it('returns empty externals', () => {
+        expect(result.externals).to.eql({ js: [], css: [] });
+      });
+
+      it('returns empty rules array', () => {
+        expect(result.rules).to.eql([]);
+      });
+    });
+
+    describe('with data', () => {
+      beforeEach(() => {
+        moduleData = {
+          extensions: ['.extension'],
+          externals: {
+            js: ['external.js'],
+            css: ['external.css']
+          },
+          rules: [
+            { test: 'test' }
+          ]
+        };
+
+        moduleRequire = stub().returns(moduleData);
+
+        return mod.load({}, 'path', moduleRequire)
+          .then(r => result = r);
+      });
+
+      it('returns the extensions', () => {
+        expect(result.extensions).to.eql(moduleData.extensions)
+      });
+
+      it('returns the externals', () => {
+        expect(result.externals).to.eql(moduleData.externals);
+      });
+
+      it('returns the rules', () => {
+        expect(result.rules).to.eql(moduleData.rules);
+      });
+
+    });
   });
 });


### PR DESCRIPTION
Closes #89

BREAKING CHANGE: You must re-install the pie cli modules directory: `rm -fr node_modules && npm install`